### PR TITLE
Initial doc generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Generating versioned documentation
+
+Clone documentation repos in parallel folders next to this one
+
+1) clone https://github.com/oskariorg/oskari-documentation -> (Should be found in ../oskari-documentation)
+2) clone https://github.com/oskariorg/oskari-frontend -> (Should be found in ../oskari-frontend)
+3) VERSION=2.13.0 npm run docs
+
+This:
+- shovels in everything under `oskari-documentation`` to `_content/docs/[version]/`
+- copies `ReleaseNotes.md` and `api/CHANGELOG.md` to  `_content/docs/[version]/2 Application functionality/`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Clone documentation repos in parallel folders next to this one
 
 1) clone https://github.com/oskariorg/oskari-documentation -> (Should be found in ../oskari-documentation)
 2) clone https://github.com/oskariorg/oskari-frontend -> (Should be found in ../oskari-frontend)
-3) VERSION=2.13.0 npm run docs
+3) Run `npm run docs --DOC_V=[version]` where `[version]` is like `2.13.0`
 
 This:
 - shovels in everything under `oskari-documentation`` to `_content/docs/[version]/`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "docs": "node scripts/generateDocs.js"
   },
   "browser": {
     "fs": false,

--- a/scripts/generateDocs.js
+++ b/scripts/generateDocs.js
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const fs = require('fs');
+//const { lstatSync, readdirSync, existsSync } = require('fs');
+const path = require('path');
+
+const pathToExternalRepos = path.normalize(path.join(__dirname, '/../../'));
+const version = process?.env?.DOC_VERSION;
+
+if (!version) {
+  // SET DOC_VERSION=2.13.0
+  throw new Error('Env variable DOC_VERSION is required');
+}
+
+// init folder for version
+const pathToVersionRoot = path.normalize(path.join(__dirname, '/../_content/docs/', version));
+if (!fs.existsSync(pathToVersionRoot)) {
+  fs.mkdirSync(pathToVersionRoot, { recursive: true });
+  console.log('Created folder for version ' + version + ' in:' + pathToVersionRoot);
+}
+
+// shovel in the documentation from the other repo (https://github.com/oskariorg/oskari-documentation)
+const pathToDocumentationRepository = path.join(pathToExternalRepos, 'oskari-documentation/');
+fs.cpSync(pathToDocumentationRepository, pathToVersionRoot, {
+  preserveTimestamps: true,
+  recursive: true
+});
+console.log('Initialized docs for version ' + version);
+
+
+// https://github.com/oskariorg/oskari-frontend
+const pathToFrontendRepository = path.join(pathToExternalRepos, 'oskari-frontend/');
+const pathToBundlesDocumentation = path.join(pathToVersionRoot, '2 Application functionality/');
+
+const filesToCopy = ['ReleaseNotes.md', 'api/CHANGELOG.md'];
+// TODO: parse the matching version from files and write a page about only current version?
+//  (include link to release notes on GitHub)
+filesToCopy.forEach(file => fs.copyFileSync(path.join(pathToFrontendRepository, file), path.join(pathToBundlesDocumentation, path.basename(file))));
+
+// TODO: read bundle docs from pathToFrontendRepository + api/**/bundle.md etc
+//  - generate flattened listing of bundles + their requests + events
+//  - maybe as a secondary effort try to create links from bundles using the requests/events to ones providing the
+// current code in https://github.com/oskariorg/oskari-docs/tree/master/lib (oskariapi related files/code) maybe helpful

--- a/scripts/generateDocs.js
+++ b/scripts/generateDocs.js
@@ -4,11 +4,11 @@ const fs = require('fs');
 const path = require('path');
 
 const pathToExternalRepos = path.normalize(path.join(__dirname, '/../../'));
-const version = process?.env?.DOC_VERSION;
+// npm run docs --DOC_V=2.13.0
+const version = process?.env?.npm_config_DOC_V;
 
 if (!version) {
-  // SET DOC_VERSION=2.13.0
-  throw new Error('Env variable DOC_VERSION is required');
+  throw new Error('Parameter `--DOC_V=version` is required');
 }
 
 // init folder for version
@@ -22,9 +22,12 @@ if (!fs.existsSync(pathToVersionRoot)) {
 const pathToDocumentationRepository = path.join(pathToExternalRepos, 'oskari-documentation/');
 fs.cpSync(pathToDocumentationRepository, pathToVersionRoot, {
   preserveTimestamps: true,
-  recursive: true
+  recursive: true,
+  // filter out git metadata so we don't get accidental git submodules
+  filter: (src) => !path.basename(src).startsWith('.git')
 });
 console.log('Initialized docs for version ' + version);
+
 
 
 // https://github.com/oskariorg/oskari-frontend


### PR DESCRIPTION
Script for generating versioned documentation.

Clone documentation repos in parallel folders next to this one

1) clone https://github.com/oskariorg/oskari-documentation -> (Should be found in ../oskari-documentation)
2) clone https://github.com/oskariorg/oskari-frontend -> (Should be found in ../oskari-frontend)
3) npm run docs --DOC_V=2.13.0

This:
- shovels in everything under `oskari-documentation` to `_content/docs/[version]/`
- copies `ReleaseNotes.md` and `api/CHANGELOG.md` to  `_content/docs/[version]/2 Application functionality/`