### PR TITLE
Copy/pasted blogs from current impl

### DIFF
--- a/_content/blog/2016-12-20-PSC_The_Beginning.md
+++ b/_content/blog/2016-12-20-PSC_The_Beginning.md
@@ -1,0 +1,107 @@
+---
+layout: post
+title:  "OSGeo PSC - The beginning"
+excerpt : "While not an actual PSC meeting this meeting introduced the OSGeo process and the first PSC was elected in the meeting."
+date:   2016-12-20 13:00:00 +0200
+categories: [psc, psc-memo]
+---
+
+# Oskari Architecture Group Meeting Memo
+
+While not an actual PSC meeting this meeting introduced the OSGeo process and the first PSC was elected in the meeting.
+
+## Opening the meeting
+
+Introduction of participants:
+
+- Jani Kylmäaho, National Land Survey of Finland
+- Sanna Jokela, Gispo Ltd
+- Jan Lindbom, Dimenteq Ltd
+- Marko Kauppi, City of Tampere
+- Pekka Sarkola, Gispo Ltd
+- Sami Mäkinen, National Land Survey of Finland
+- Sampo Savolainen, Spatineo Ltd
+- Jaakko Leikko,Siili Ltd
+- Tuuli Pihlajamaa, Statistical Institute of Finland
+- Jussi Arpalahti, City of Helsinki
+- Jaakko Ruutiainen, Sito Ltd
+- Timo Sallinen, NLS FI
+- Hafliði Sigtryggur Magnússon, National Land Survey of Island
+- Ásta Kristin Óladóttir, National Land Survey of Iceland
+- Marko Kuosmanen, Dimenteq Ltd
+- Heikki Ylitalo, Dimenteq Ltd
+- Hanno Kuus, National Land Survey of Estonia
+- Igor Paharikov, Moldovian Geospatial Agency
+- Tomi Lukkarinen, Helsinki Region Environmental Services
+
+The agenda was approved
+
+## Introduction to Oskari OSGeo progress
+
+- Jani Kylmäaho presented the background for arranging the meeting and stated that it is
+time to give Oskari.org software to the community to foster. Nevertheless, National
+Land Survey of Finland will continue to be actively participating in the development and
+collaboration activities also in the future.
+- Sanna Jokela presented the <a href="/files/20161220-Oskari_OSGEO_PSC.pdf" target="_blank">themes behind the Oskari development and OSGeo
+processes</a>. To become part of OSGeo brings open source geospatial projects stability
+and international visibility. Certain requirements have to be fulfilled, one being the
+establishment of Project Steering Committee (PSC) for Oskari.
+- Sanna Jokela introduced the drafts for Community Roles, PSC tasks & rules and Oskari
+Roadmap. These documents were discussed.
+
+### Comments for Oskari Community Roles:
+
+- [Link to Github wiki](https://github.com/nls-oskari/oskari.org/wiki/Roles-of-Oskari-Community)
+- Coordinator should be added to the list and describe how community events
+and activation methods are to be conducted
+
+### Comments for Project Steering Committee (PSC) tasks, roles and rules:
+
+- [Link to Github wiki](https://github.com/nls-oskari/oskari.org/wiki/Project-Steering-Committee)
+- Just to clarify:
+1. The membership of the PSC is stable, unless the member wants to
+step down or is voted to step down (e.g. due to inactivity)
+2. Members are individuals, not organisational representatives
+3. Members can be added afterwards or invited to the group by the PSC
+- Communication methods should be open - everybody should see the
+suggested features and votes given to these. Email is not the only discussion
+forum for the issues and private email list should not be created for the PSC.
+This will be added to the rules.
+- Voting should be possible with any digital method proven suitable for the group
+(e.g email, slack, github). This will be added to the rules.
+
+### Oskari Roadmap
+- [Link to Github wiki](https://github.com/nls-oskari/oskari.org/wiki/Oskari-Improvement-Proposals-and-Roadmap)
+- This is a draft and needs to be refined by the PSC in their first meeting
+
+## Establishing Oskari PSC
+
+- Following nominees were made for the Oskari Project Steering Committee and all
+nominated were elected as members of the PSC:
+	- Jussi Arpalahti
+	- Marko Kauppi
+	- Jaakko Ruutiainen
+	- Tuuli Pihlajamaa
+	- Hafliði Sigtryggur Magnússon
+	- Sami Mäkinen
+	- Timo Sallinen
+	- Tomi Lukkarinen
+	- Heikki Ylitalo
+
+- Election of the chair: Sami Mäkinen was suggested to be the chair and was elected for the chair. Decision was unanimous.
+- Establishing the rules: The rules were established with minor corrections. They can be further revised by the PSC if needed.
+
+##  Next steps
+
+First Oskari PSC meeting: The Chair will suggest the PSCs first meeting on January 2017. Refining the Roadmap is the first priority of the PSC.
+
+### OSGeo Incubation process next steps
+- CLA’s are needed from all contributors, the request for these will be sent out soon
+- Oskari will apply for the OSGeo Incubation process before the end of December 2016
+- PSC and Coordination of the Oskari Network will collaborate on the incubation process after instructions from the OSGeo
+
+### Other issues:
+- Jani Kylmäaho will assist the work of PSC if needed
+- PSCs job is seen crucial for the success of Oskari
+
+#### Meeting was closed 14:47 UTC +2.

--- a/_content/blog/2016-12-20-PSC_The_Beginning.md
+++ b/_content/blog/2016-12-20-PSC_The_Beginning.md
@@ -4,6 +4,7 @@ title:  "OSGeo PSC - The beginning"
 excerpt : "While not an actual PSC meeting this meeting introduced the OSGeo process and the first PSC was elected in the meeting."
 date:   2016-12-20 13:00:00 +0200
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # Oskari Architecture Group Meeting Memo

--- a/_content/blog/2016-12-20-PSC_The_Beginning.md
+++ b/_content/blog/2016-12-20-PSC_The_Beginning.md
@@ -4,7 +4,7 @@ title:  "OSGeo PSC - The beginning"
 excerpt : "While not an actual PSC meeting this meeting introduced the OSGeo process and the first PSC was elected in the meeting."
 date:   2016-12-20 13:00:00 +0200
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # Oskari Architecture Group Meeting Memo

--- a/_content/blog/2016-12-23-PSC_member_changes.md
+++ b/_content/blog/2016-12-23-PSC_member_changes.md
@@ -4,6 +4,7 @@ title:  "OSGeo PSC - New member"
 excerpt : "The first vote of the PSC was to add a new Member to the team: Marko Kuosmanen"
 date:   2016-12-23
 categories: [psc]
+tags: [blog]
 ---
 
 # OSGeo PSC first actions

--- a/_content/blog/2016-12-23-PSC_member_changes.md
+++ b/_content/blog/2016-12-23-PSC_member_changes.md
@@ -4,7 +4,7 @@ title:  "OSGeo PSC - New member"
 excerpt : "The first vote of the PSC was to add a new Member to the team: Marko Kuosmanen"
 date:   2016-12-23
 categories: [psc]
-tags: [blog]
+tags: blog
 ---
 
 # OSGeo PSC first actions

--- a/_content/blog/2016-12-23-PSC_member_changes.md
+++ b/_content/blog/2016-12-23-PSC_member_changes.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title:  "OSGeo PSC - New member"
+excerpt : "The first vote of the PSC was to add a new Member to the team: Marko Kuosmanen"
+date:   2016-12-23
+categories: [psc]
+---
+
+# OSGeo PSC first actions
+
+Closely following the initial PSC election a new individual informed of his interest to join the PSC.
+
+A quick vote was arranged in Slack for adding a new member:
+Marko Kuosmanen has been working on the core Oskari team for a few years already and the vote was unanimously for him joining the PSC.
+
+The current steering committee is:
+
+- Jussi Arpalahti
+- Marko Kauppi
+- Jaakko Ruutiainen
+- Tuuli Pihlajamaa
+- Hafliði Sigtryggur Magnússon
+- Sami Mäkinen
+- Timo Sallinen
+- Tomi Lukkarinen
+- Heikki Ylitalo
+- Marko Kuosmanen
+
+## Next steps
+
+The first actual meeting is at the end of January 2017. Roadmap issues and other topics for discussion are being gathered. If you want to raise an issue for the roadmap to be discussed on the meeting, you should do it by 16.1.2017. Instructions to do so can be found [here](https://github.com/nls-oskari/oskari.org/wiki/Roadmap-process).

--- a/_content/blog/2017-01-26-PSC_January_2017.md
+++ b/_content/blog/2017-01-26-PSC_January_2017.md
@@ -4,7 +4,7 @@ title:  "OSGeo PSC - January meeting 2017"
 excerpt : "The role of the PSC and practical actions needed by the PSC were discussed. What is required for a roadmap item? What are the requirements for accepting pull requests? etc"
 date:   2017-01-26 13:00:00 +0200
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # January meeting 2017

--- a/_content/blog/2017-01-26-PSC_January_2017.md
+++ b/_content/blog/2017-01-26-PSC_January_2017.md
@@ -4,6 +4,7 @@ title:  "OSGeo PSC - January meeting 2017"
 excerpt : "The role of the PSC and practical actions needed by the PSC were discussed. What is required for a roadmap item? What are the requirements for accepting pull requests? etc"
 date:   2017-01-26 13:00:00 +0200
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # January meeting 2017

--- a/_content/blog/2017-01-26-PSC_January_2017.md
+++ b/_content/blog/2017-01-26-PSC_January_2017.md
@@ -1,0 +1,163 @@
+---
+layout: post
+title:  "OSGeo PSC - January meeting 2017"
+excerpt : "The role of the PSC and practical actions needed by the PSC were discussed. What is required for a roadmap item? What are the requirements for accepting pull requests? etc"
+date:   2017-01-26 13:00:00 +0200
+categories: [psc, psc-memo]
+---
+
+# January meeting 2017
+
+The PSC gathered to discuss the following agenda:
+
+- What should be the practical development process for Oskari and what is the role of the PSC in this.
+- Requirements for pull requests
+- Who can do a review for a pull request.
+- What kind of code is accepted to the Oskari-repository and what should be cleaned out of it.
+- How to handle bigger UI changes (and how to decide what is big UI change) on the application components.
+- Do we need namespaces on the bundles or can we flatten the directory structure?
+- Naming of Oskari classes, events, requests etc in future development
+- Other coding style decisions like get/set change in the core.
+- Roadmap issues.
+- Other issues
+
+## Opening the meeting
+
+Attendees:
+
+- Sami Mäkinen
+- Jaakko Ruutiainen
+- Tuuli Pihlajamaa
+- Jussi Arpalahti
+- Tomi Lukkarinen
+- Marko Kauppi
+- Timo Sallinen
+
+Via conference call:
+
+- Heikki Ylitalo
+- Marko Kuosmanen
+
+Not present:
+
+- Hafliði Sigtryggur Magnússon
+
+## Development process
+
+The development process and code flow was discussed from practical point-of-view. Customization being done on top of Oskari usually have a tight schedule and developers can't be expected to wait for pull requests to be accepted before moving on with the development of a feature.
+
+Developers need to fork the Oskari-repository that require changes and continue working on the feature while submitting pull requests. There are also cases where multiple developers from different companies are implementing features on top of Oskari to be used in a customized Oskari-instance. These changes might need to go live on that instance before the code is merged to the official Oskari-repository. In these cases the organization with the customized Oskari-instance should have their own fork of the Oskari-repositories. Pull requests that have been sent to Oskari-repositories can then be merged to the customized fork even before they are accepted to the official repository.
+
+### Oskari Improvement Proposal (OIP)
+
+We need to provide practical instructions how to contribute. Like when you start working on new functionality:
+
+- make plans of functionalities for the PSC to approve
+- evaluate whether a new bundle is needed
+- evaluate if there are requirements for existing code to provide hooks for the new functionality?
+
+Challenges:
+
+- client paying for the change may want to alter requirements after OIP has been submitted
+- When is an OIP required instead of a simple pull request?
+
+## Requirements for pull requests
+
+Discussed about automated tests, the need for implementing a base for front-end testing that can be extended, test coverage requirements and Travis CI for automatically checking pull requests against test-suites. We need a checklist for doing the reviews.
+
+No decisions were made yet.
+
+## Who can do a review for a pull request
+
+It was agreed that not everyone in the PSC is able to review code changes/pull requests so this should not be limited to members of the PSC.
+
+On further discussion it was agreed that the GeoServer-project has documented their approach on these issues and we could use the same practical approach:
+
+- [Commits](http://docs.geoserver.org/latest/en/developer/policies/committing.html)
+- [Pull requests](http://docs.geoserver.org/latest/en/developer/policies/pull_request.html)
+- [Reviews](http://docs.geoserver.org/latest/en/developer/policies/review.html)
+
+We also discussed that we should work on increasing the number of developers with core commit access to keep a review queue from building up.
+
+## What kind of code is accepted to the Oskari-repository and what should be cleaned out of it.
+
+Sami introduced changes for the new release with sources-folder being removed and the actual Oskari-core  now included in the src-folder. The core offers the basic framework to run actual functionalities that are located in the bundles-folder.
+
+It was decided that the current frontend-repository should be cleaned up. Any application-specific functionalities should be moved to a new community-repository (naming still under consideration). The code that remains in the Oskari-repository needs to have a responsible party for maintaining the functionality and everything in the repository should be documented (usage, configuration etc) and working with the latest Oskari version. If a bundle is no longer maintained and no-one else claims responsibility it will be moved to the community-repository. Commit access to the Oskari-repository could be granted by gaining the trust of the previous core committers (similar to the GeoServer-project).
+
+The community-repository could have more relaxed requirements. Commit access could be granted for anyone working with Oskari and the functionality bundles are not expected to work on the latest Oskari version. These bundles need to declare the last known version of Oskari they have been used with.
+
+Sami will make a suggestion what bundles are to be moved out of the Oskari-repository and provide an example how to use the community-bundles in an Oskari-application.
+
+## How to handle UI changes
+
+This is related to the requirements of pull requests and needs to be discussed further.
+
+No decisions were made.
+
+## Do we need namespaces on the bundles
+
+Cleaning up the Oskari-repository will make this decision easier.
+
+No decisions were made yet.
+
+## Naming of Oskari classes, events, requests etc in future development
+
+Naming of functions, events and requests was discussed. Sami introduced a new style for get/set-functions in the core with:
+
+	// get value
+	value()
+	//set value
+	value(10)
+
+A decision is required whether we should use this way or separate functions as coding style.
+
+Another issue is the naming of events and requests. There's currently no rules on the naming with some of the names including reference to the bundle that offers them and some not. Also the reference is not the actual bundle id, but some variation of it. Challenge in this is that old events/requests cannot be renamed without backwards compatibility as it breaks a lot of features/RPC-enabled applications. An example for new naming scheme was introduced here: [https://github.com/nls-oskari/oskari/blob/develop/bundles/mapping/mapmodule/event/map.layer.activation.js](https://github.com/nls-oskari/oskari/blob/develop/bundles/mapping/mapmodule/event/map.layer.activation.js)
+
+No decision was made yet, but it was agreed that the code should be consistent. Discussion will be continued in Slack.
+
+## Roadmap(/GitHub) issues
+
+Discussed challenges of choosing roadmap issues based on very limited information.
+
+### Labels
+
+Labels are used to separate issues between bugs, enhancements/wishlist, roadmap and OIPs:
+
+- Bug labeled issues should be described with helpful information like Oskari version, browser information and/or steps to reproduce.
+- Roadmap label is used for issues that don't have detailed plans, but have funding/real commitment from a contributor/organization. Roadmap issue can have very short description about a planned feature with information about the committed party.
+- Enhancement label is used for issues that would be nice, but no-one is currently committed on making it happen. Kind of a "wishlist".
+- OIP label is used for Oskari improvement proposals. The content should be detailed with template provided on the GitHub-wiki.
+- Documentation label is used for issues concerning the support site (oskari.org).
+
+### Roadmap listing
+
+Having the roadmap items listed on [http://oskari.org](http://oskari.org) was discussed. This could be done using the GitHub API. A documentation issue was added to GitHub and Jussi agreed to take a look at this.
+
+### Progress tracking
+
+Tracking the progress of issues on the repository was discussed. The PSC agreed on using the Waffle.io service for this purpose as it's lightweight and only manages the labels of issues so it's easily replaceable. Sami will take a look at this.
+
+Contributor permissions will be added to PSC members for github.com/nls-oskari/oskari.org -repository. Sami will take care of this.
+
+## Other issues
+
+### GitHub repository naming
+
+Concerns have been raised about having nls in the name of the GitHub account for Oskari. The PSC agreed on moving the repositories under different account/GitHub-organization.
+
+After further discussion [https://github.com/oskariorg](https://github.com/oskariorg) was reserved for the new name. Repository move needs to be coordinated and possibly have the current repository urls preserved with a note about the new location. Links in the OSGeo incubation application and all over oskari.org need to be updated.
+
+### Oskari-showcase
+
+[http://demo.oskari.org](http://demo.oskari.org) is the showcase site for Oskari. It should have the latest released version of Oskari and showcase all the supported functionality. A gallery-style frontpage should be implemented so the user can select to see different kind of appsetups implemented with Oskari. This way we don't need to use every supported bundle in one sample-application. A development environment is also required for testing changes and pull requests.
+
+Sami will investigate what it would mean to setup dev.oskari.org (possibly on the same server as demo.oskari.org).
+
+### Things to consider
+
+Do we want to keep feature branches in the public repository? Do we want save branch history? Do we rebase pull requests? Branches might show which code was related to which feature at the time they are done, but propably don't offer much after some time has passed. Git blame might be better suited for this kind of forensics. Homework for everyone: familiarize with GitFlow documentation. Discussions on the matter will be continued on Slack. No decisions were made on these.
+
+### Future meetings
+
+Agreed on not having regular meeting schedule, but having meetings when required. Most of the work can propably be done online.

--- a/_content/blog/2017-03-01-Repository_changes.md
+++ b/_content/blog/2017-03-01-Repository_changes.md
@@ -4,6 +4,7 @@ title:  "Repository relocation in March 2017"
 excerpt : "Git-repositories will be moved from nls-oskari to new organization oskariorg in March!"
 date:   2017-03-01 13:00:00 +0200
 categories: [documentation]
+tags: [blog]
 ---
 
 # Repository relocation in March 2017

--- a/_content/blog/2017-03-01-Repository_changes.md
+++ b/_content/blog/2017-03-01-Repository_changes.md
@@ -4,7 +4,7 @@ title:  "Repository relocation in March 2017"
 excerpt : "Git-repositories will be moved from nls-oskari to new organization oskariorg in March!"
 date:   2017-03-01 13:00:00 +0200
 categories: [documentation]
-tags: [blog]
+tags: blog
 ---
 
 # Repository relocation in March 2017

--- a/_content/blog/2017-03-01-Repository_changes.md
+++ b/_content/blog/2017-03-01-Repository_changes.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title:  "Repository relocation in March 2017"
+excerpt : "Git-repositories will be moved from nls-oskari to new organization oskariorg in March!"
+date:   2017-03-01 13:00:00 +0200
+categories: [documentation]
+---
+
+# Repository relocation in March 2017
+
+The codebase for Oskari will move from under the [nls-oskari](https://github.com/nls-oskari) user to a GitHub-organization [oskariorg](https://github.com/oskariorg). Some of the repositories will be renamed for clarity.
+
+This is done as part of the process of Oskari becoming an OSGeo project.
+
+## Plans
+
+### Frontend
+
+- Current repository: [https://github.com/nls-oskari/oskari](https://github.com/nls-oskari/oskari)
+- New repository: [https://github.com/oskariorg/oskari-frontend](https://github.com/oskariorg/oskari-frontend)
+- Some of the bundles (app-specific etc) will be relocated here: [https://github.com/oskariorg/oskari-frontend-community](https://github.com/oskariorg/oskari-frontend-community)
+
+
+### Server
+
+- Current repository: [https://github.com/nls-oskari/oskari-server](https://github.com/nls-oskari/oskari-server)
+- New repository: [https://github.com/oskariorg/oskari-server](https://github.com/oskariorg/oskari-server)
+
+### Support site ([http://oskari.org](http://oskari.org))
+
+- Current oskari.org site, Oskari roadmap/issues/wiki including OSGeo stuff: [https://github.com/nls-oskari/oskari.org](https://github.com/nls-oskari/oskari.org)
+- New support site: [https://github.com/oskariorg/oskari-docs](https://github.com/oskariorg/oskari-docs)
+
+### Developer blog/PSC notes
+
+- Current developer blog/PSC-memos: [https://nls-oskari.github.io](https://nls-oskari.github.io) ([https://github.com/nls-oskari/nls-oskari.github.io](https://github.com/nls-oskari/nls-oskari.github.io))
+- New developer blog/PSC-memos: [https://oskariorg.github.io](https://oskariorg.github.io) ([https://github.com/oskariorg/oskariorg.github.io](https://github.com/oskariorg/oskariorg.github.io))
+
+## Others
+
+Rest of the repositories under [https://github.com/nls-oskari](https://github.com/nls-oskari) will be relocated as is to [https://github.com/oskariorg](https://github.com/oskariorg).
+ Except oskari-liferay and SlickGrid which will remain under nls-oskari for now and propably be removed before/during the summer.

--- a/_content/blog/2017-04-06-PSC_April_2017.md
+++ b/_content/blog/2017-04-06-PSC_April_2017.md
@@ -1,0 +1,110 @@
+---
+layout: post
+title:  "OSGeo PSC - April meeting 2017"
+excerpt : "Discussion on development process with GitHub pull requests, when is an OIP required and reviewing the current roadmap items."
+date:   2017-04-06 13:00:00 +0200
+categories: [psc, psc-memo]
+---
+
+# April meeting 2017
+
+The PSC gathered to discuss the following agenda:
+
+- thoughts on the current development process
+- when does one need to do an OIP
+- review the roadmap items
+- GitHub Projects/Waffle.io discussion
+- Other topics
+
+## Opening the meeting
+
+Attendees:
+
+- Sami Mäkinen
+- Jaakko Ruutiainen
+- Tuuli Pihlajamaa
+- Jussi Arpalahti
+- Marko Kauppi
+- Timo Sallinen
+- Marko Kuosmanen
+
+Via conference call:
+
+- Heikki Ylitalo
+- Hafliði Sigtryggur Magnússon
+
+Not present:
+
+- Tomi Lukkarinen
+
+## Development process
+
+Quick review of the updated documents:
+
+- [http://oskari.org/documentation/development/how-to-contribute](http://oskari.org/documentation/development/how-to-contribute)
+- [http://oskari.org/documentation/development/issuetypes](http://oskari.org/documentation/development/issuetypes)
+- [http://oskari.org/documentation/development/guidelines](http://oskari.org/documentation/development/guidelines)
+- [http://oskari.org/documentation/development/oskari-git-process](http://oskari.org/documentation/development/oskari-git-process)
+- [http://oskari.org/documentation/development/review](http://oskari.org/documentation/development/review)
+
+The review part is mostly copied from the GeoServer project. It will
+evolve once we gain more experience on the subject.
+
+It was noted that we need to be clear how to handle backwards incompatible changes.
+We need to have documentation about this on oskari.org.
+
+For the frontend the "public" API that should remain compatible or any changes need to
+be documented are:
+
+- functions in the Oskari global variable
+- functions for the bundle/module lifecycle spec (start/stop etc)
+
+For bundles:
+
+- requests
+- events
+- services
+- configuration
+- state
+
+For backend at least:
+
+- action route parameters
+- action route responses
+
+## Oskari Improvement Proposal (OIP)
+
+An OIP is needed when some fundamental functionality changes.
+An OIP is not needed for new functionality or functionality built on existing code.
+
+Examples for OIPs:
+
+- Migrating the geoportal views to Openlayers 3 (there could be geoportals with custom code that will break)
+- Maplayers can be grouped, but a layer can only belong to one group. A change that will enable layers to belong to multiple groups requires an OIP as it changes the way layers are loaded to frontend and will break existing functionality if not patched.
+
+Examples not requiring OIP:
+
+- new bundle (frontend)
+- Adding Openlayers 3 support for bundles (frontend)
+- new action route (server)
+- new search channel (server)
+
+## Roadmap
+
+All current roadmap items in GitHub was reviewed and accepted.
+
+A new label was added: "proposal".
+All new roadmap items will be first tagged with the proposal label in addition
+ to roadmap label. Once the item is accepted the proposal label is removed.
+This means that the official roadmap is issues with only the roadmap label.
+
+## Waffle.io/GitHub projects
+
+It was agreed that currently we don't really need either.
+
+The decision to use additional tools for managing issues was postponed.
+Once we have a proper use case and need for additional tools we can continue the discussion.
+
+## Other topics
+
+We should have some responsible and well defined way to deal with and communicate about possible security issues/vulnerabilities. Also possibility to report security issues in a way that is not completely public.

--- a/_content/blog/2017-04-06-PSC_April_2017.md
+++ b/_content/blog/2017-04-06-PSC_April_2017.md
@@ -4,6 +4,7 @@ title:  "OSGeo PSC - April meeting 2017"
 excerpt : "Discussion on development process with GitHub pull requests, when is an OIP required and reviewing the current roadmap items."
 date:   2017-04-06 13:00:00 +0200
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # April meeting 2017

--- a/_content/blog/2017-04-06-PSC_April_2017.md
+++ b/_content/blog/2017-04-06-PSC_April_2017.md
@@ -4,7 +4,7 @@ title:  "OSGeo PSC - April meeting 2017"
 excerpt : "Discussion on development process with GitHub pull requests, when is an OIP required and reviewing the current roadmap items."
 date:   2017-04-06 13:00:00 +0200
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # April meeting 2017

--- a/_content/blog/2017-12-14-PSC_December_2017.md
+++ b/_content/blog/2017-12-14-PSC_December_2017.md
@@ -4,7 +4,7 @@ title:  "OSGeo PSC - December meeting 2017"
 excerpt : "The maintainability of codebase were discussed with a decision to move some of the functionalities to a community repository. Future plans and current development as discussed."
 date:   2017-12-14 13:00:00 +0200
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # December meeting 2017

--- a/_content/blog/2017-12-14-PSC_December_2017.md
+++ b/_content/blog/2017-12-14-PSC_December_2017.md
@@ -1,0 +1,104 @@
+---
+layout: post
+title:  "OSGeo PSC - December meeting 2017"
+excerpt : "The maintainability of codebase were discussed with a decision to move some of the functionalities to a community repository. Future plans and current development as discussed."
+date:   2017-12-14 13:00:00 +0200
+categories: [psc, psc-memo]
+---
+
+# December meeting 2017
+
+The PSC gathered to discuss the following agenda:
+
+- Security audit results
+- Maintainability and community modules
+- Thoughts of future at NLS Finland
+- Discussion: SAML-support, projects/current development, future plans/meetings/activity
+- Roadmap issues
+- Other issues
+
+## Opening the meeting
+
+Attendees:
+
+- Sami Mäkinen
+- Jaakko Ruutiainen
+- Tuuli Pihlajamaa
+- Marko Kauppi
+- Marko Kuosmanen
+
+Via conference call:
+
+- Jussi Arpalahti
+- Heikki Ylitalo
+- Hafliði Sigtryggur Magnússon
+
+Not present:
+
+- Timo Sallinen
+- Tomi Lukkarinen
+
+## Security audit results
+
+Sami described the findings on the security audit. We strongly advise everyone to update to the latest version as soon as possible.
+
+## Maintainability and community modules
+
+Sami described the problem of merging more and more of new functionalities and how it affects the ability to ensure they actually work with a new release. One solution would be that we keep doing what we have done and release new functionalities with "it works if not proven otherwise" mentality and the other option is to make an effort to truly keep the core as bug free as possible and introduce new functionalities that might or might not work with the latest release as "community modules".
+
+It was decided that a community modules repository will be added to oskariorg repositories for server as well as frontend. Functionalities such as the download basket, analysis and any application specific code that we currently have in the codebase will be moved to community modules. When a new functionality is introduced it should only be added to the core if we can assure that it will be updated for each release.
+
+## Thoughts of future at NLS Finland
+
+NLS Finland has been thinking of doing proof of concepts with Webpack, TypeScript/ES6+ based version of Oskari frontend with React or Vue.js as the view library. This will probably mean backwards compatibility being broken in one way or another, but it was agreed that upgrading to a new technology stack is something we want to do for keeping up with the tech and attract more developers. The first steps are taken in 2018 and great care is needed to ensure that communication of the change is properly done (migration guide should be provided and old version probably maintained side-by-side for some time). RPC will also be reflected mostly by changing request/event names that are easy to find/replace in existing applications. The discussion will be continued when we have more concrete information about this, but initial ok has been given by the PSC.
+
+## Removal of SAML-support
+
+The spring SAML-module ([https://projects.spring.io/spring-security-saml/](https://projects.spring.io/spring-security-saml/)) isn't actively maintained and is currently blocking some of the library updates that would otherwise improve Oskari. Tampere is heavily invested in using the SAML integration, but support for SAML-based login could be lifted from Oskari to Apache/loadbalancer level. It was agreed that SAML-support can be removed from Oskari in order to update the other libraries.
+
+## Projects/current development/future plans
+
+### Iceland
+- mostly adding data to Oskari
+- no new development
+- plans to use thematic maps next year
+- currently upgrading to new version
+- problems with update due to missing/changed translations (Updated only for en, fi, sv)
+
+### Helsinki
+- no hosted Oskari instance so no new development
+- mostly layers added to map.geoportal.fi provided by NLS Finland
+
+### Tampere
+- 1.44.x version in use
+- hierarchical layer selector development starting
+
+### SITO
+- Oskari instance at museovirasto upgraded to 1.44.x
+- Some pull requests for bugfixes can be expected
+- Liiteri updated to newer Oskari next year after new layer selector is available
+
+### Tilastokeskus
+- hosted Oskari instance for intranet usage
+- no new development other than thematic maps with NLS Finland
+
+### Dimenteq
+- HSY Oskari instance update next year
+- layer selector implementation will be done by Dimenteq ([https://github.com/oskariorg/oskari-docs/issues/61](https://github.com/oskariorg/oskari-docs/issues/61))
+- lot of development built on top of RPC (troubled by backwards compatibility being possibly broken next year)
+
+### NLS Finland
+- thematic maps rewrite mostly ready
+- OpenLayers 4 support for geoportal functionalities nearly ready (OIP needed before forcing to all Oskari instances)
+- 3D-mapmodule POC's next year (most likely as community module)
+- POC to modernize the frontend tech stack (TypeScript/React/Vue.js)
+
+## Roadmap issues
+
+Layer selector OIP approved ([https://github.com/oskariorg/oskari-docs/issues/61](https://github.com/oskariorg/oskari-docs/issues/61)) and tagged as roadmap item so it can be found through roadmap listing as new development. The actual change to current code is that layer groups (themes/data providers can have multiple levels) and layers can belong to multiple groups. The OIP also covers new optional user interface for layer listing and layer administration. Old admin and layer listing bundles will be updated to support layers belonging to multiple groups, but will not support the tree structure for groups.
+
+## Meetings/activity
+
+- OIP for ol4 migration will be done by Sami
+- future meetings schedule: continue with "as needed" (no need for a fixed schedule)
+- Slack/Mailinglist can be used more actively to discuss any issues/voting

--- a/_content/blog/2017-12-14-PSC_December_2017.md
+++ b/_content/blog/2017-12-14-PSC_December_2017.md
@@ -4,6 +4,7 @@ title:  "OSGeo PSC - December meeting 2017"
 excerpt : "The maintainability of codebase were discussed with a decision to move some of the functionalities to a community repository. Future plans and current development as discussed."
 date:   2017-12-14 13:00:00 +0200
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # December meeting 2017

--- a/_content/blog/2018-08-14-PSC_August_2018.md
+++ b/_content/blog/2018-08-14-PSC_August_2018.md
@@ -4,6 +4,7 @@ title:  "OSGeo PSC - August meeting 2018"
 excerpt : "OSGeo incubation status, modern tools like React were discussed"
 date:   2018-08-14 15:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # August meeting 2018

--- a/_content/blog/2018-08-14-PSC_August_2018.md
+++ b/_content/blog/2018-08-14-PSC_August_2018.md
@@ -1,0 +1,110 @@
+---
+layout: post
+title:  "OSGeo PSC - August meeting 2018"
+excerpt : "OSGeo incubation status, modern tools like React were discussed"
+date:   2018-08-14 15:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# August meeting 2018
+
+The PSC gathered to discuss the following agenda:
+
+- New roadmap items
+- Improving Oskari documentation
+- Oskari Developer Summit 25.9.2018
+- OSGeo Incubation status
+
+## Opening the meeting at 15:08
+
+Via conference call:
+
+- Sami Mäkinen
+- Jaakko Ruutiainen
+- Tuuli Pihlajamaa
+- Marko Kuosmanen
+- Timo Sallinen
+- Jussi Arpalahti
+- Sanna Jokela (secretary)
+
+Not present:
+
+- Heikki Ylitalo
+- Hafliði Sigtryggur Magnússon
+- Tomi Lukkarinen
+
+## New roadmap items
+
+No new isssues to approve at the meeting
+
+3D-mapmodule is being implemented and tested with buildings from Finnish national map database and terrain model. This is not yet part of the official Oskari but is built on top of Oskari using a customized mapmodule for OL-Cesium (http://openlayers.org/ol-cesium/)
+ 
+Vector tile support coming up (NLS FI) - Sami adds this to GitHub after meeting
+
+Time series for thematic maps - Sami adds this after GitHub meeting
+
+POC: New build script 
+- Webpack (maybe to the next release, old will be removed probably after the next version) - Sami adds this to roadmap
+- React (initial bundle using React will most probably be introduced as an admin bundle rewrite)
+-- After initial testing usage might spread through out the Oskari bundles
+-- Writing a React OpenLayers wrapper have not been planned yet.
+-- There has been some tests in SitoWise Ltd for the wrapper and there are existing components available
+- TypeScript (will probably not be pursued further at this point)
+- No mentions of Leaflet - OpenLayers is the main tool for now
+
+Jetty 9 migration is being implemented which will change the packaging of the Oskari download a bit. 
+Jetty code will be more separate from Oskari. This means that server settings should be updated and documentation should be revised accordingly. - Sami adds this as roadmap item to GitHub after meeting
+
+
+## Improving documentation
+
+Improvement process is going on inside NLS & Joint Development Forum
+
+What are the most important things to correct
+- Structure - marketing pages and tech mixed 
+- Developers vs. “normal” users
+- Version information and date indicating when the documentation is done
+
+Oskari.org webpage renewal process is going on - autumn 2018 planning, spring 2019 implementation
+- Structure should be considered also when documentation is been done
+- This will be discussed with the documentation person who is doing this work
+
+
+## Oskari developer summit programme 
+
+Meeting is to be held in Helsinki on 25th of September (https://www.meetup.com/Oskari-Your-geospatial-friend/events/251877038/). The goal is to gather ideas for future Oskari.
+
+Target group: developers and project managers
+Issues for the discussion:
+- Modularity/Bundles in Oskari? 
+- Docker?
+Let’s continue discussing this through Oskari channels
+
+
+## OSGeo Incubation status discussion
+Openness and community should be addressed more
+
+Mentor did not yet recommend the graduation based on seemingly low community involvement
+
+Thus the Oskari mailing list should be used more
+
+Discussion about the different uses of current lists:
+- Rocketchat is for projects (not for open Oskari community)
+- Slack - Oskari discussion (a bot is needed to approve new members), problem is that information and discussion history is lost after a free limit is reached
+- Mailing list should be the main discussion channel
+- Could it be possible to generate General channel log straight to the mailing list? It was discussed and thought that it causes problems with the language (mostly finnish communication)
+- https://gis.stackexchange.com/  could be used more also, tags could be used, some of the PSC members should apply to become a trusted member for Oskari-related questions
+
+
+## Other issues
+
+- Crowdsourcing is on the way for finding funding for Myplaceimport pop-up-info tool improvement https://github.com/oskariorg/oskari-docs/issues/65
+- Helsinki has tested Dockerized applications and it has worked fine. Providing a dockerized Oskari would ease a lot in testing it out. This should be discussed further.
+
+
+## Next meeting
+
+Next meeting: 11.9.2018, scheduled now every month, every second week tuesday at 15:00 (GMT+3)
+
+## End of meeting: 16:05
+

--- a/_content/blog/2018-08-14-PSC_August_2018.md
+++ b/_content/blog/2018-08-14-PSC_August_2018.md
@@ -4,7 +4,7 @@ title:  "OSGeo PSC - August meeting 2018"
 excerpt : "OSGeo incubation status, modern tools like React were discussed"
 date:   2018-08-14 15:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # August meeting 2018

--- a/_content/blog/2018-09-11-PSC_September_2018.md
+++ b/_content/blog/2018-09-11-PSC_September_2018.md
@@ -1,0 +1,101 @@
+---
+layout: post
+title:  "OSGeo PSC - September meeting 2018"
+excerpt : "New roadmap items were approved, new OIP"
+date:   2018-09-11 15:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# September meeting 2018
+
+The PSC gathered to discuss the following agenda:
+
+- New roadmap items
+- Oskari Developer Summit 25.9.2018
+- Discussion channels
+- News from PSC members
+
+## Opening the meeting at 15:10
+
+Present via conference call:
+
+- Sami Mäkinen
+- Jaakko Ruutiainen
+- Tuuli Pihlajamaa
+- Marko Kuosmanen
+- Jussi Arpalahti
+- Heikki Ylitalo
+- Hafliði Sigtryggur Magnússon
+- Sanna Jokela (secretary)
+
+Not present:
+- Tomi Lukkarinen
+- Timo Sallinen
+
+## New roadmap items
+
+Following roadmap items have been provided for the PSC before hand in PSC-channel in Rocketchat a few weeks back. They have already received up-votes in GitHub.
+
+Update Jetty version: https://github.com/oskariorg/oskari-docs/issues/67
+
+Initial vector tile support: https://github.com/oskariorg/oskari-docs/issues/68
+- was regarded as a good feature
+
+Timeseries support: https://github.com/oskariorg/oskari-docs/issues/69 
+- this should be opened a little bit more in Github, otherwise good to go
+
+Frontend stack modernization: https://github.com/oskariorg/oskari-docs/issues/70 
+- Marko: nice features
+- Sanna: more broad description please in the future so that all can understand what is happening. 
+- Sami: we want to get rid of the old build script. OpenLayers has moved to new Webpack also. 
+- All in all, this was considered as a good improvment.
+
+All roadmap items above were approved.
+
+## OIP
+
+Layer permissions handling change https://github.com/oskariorg/oskari-docs/issues/72 
+- this has caused problems before, the improvement makes permissions more clear for layers. 
+- this was regarded as good OIP
+- everybody can comment on the OIP or vote for it in GitHub after the meeting. 
+- if it gets up-voted, it is going to be added as a roadmap item soon.
+ 
+## Reminder: Oskari developer summit coming up
+
+Please sign in: https://www.meetup.com/Oskari-Your-geospatial-friend/events/251877038/. 
+The event will be held in Helsinki on 25.9.2018 and Oskari roadmap for the future is drafted there.
+
+## Discussion channels
+
+There has not been activity on Slack - any reason for this? 
+
+- Rocketchat has been taken in use in NLS-FI sine June 2018 for projects and at the same time Slack activity has gone down.
+- Slack still needs registration and there could be only the “general” channel in use, but it still needs creating automation for registration
+- Sami and Sanna have been testing also Githubs own chat Gitter https://gitter.im/oskariorg/chat. The pros of this media is that all the discussions are visible thourgh search engines. It is in use also e.g. GeoNode and is totally open.
+
+It was decided to vote what instant messaging channel should be used:
+
+- Heikki: Slack better technically, no strong opinion on this
+- Jussi: One public channel would be best, preferably email since it’s easiest to follow intermittently 
+- Marko Kuosmanen: no strong opinion
+- Marko Kauppi:  no strong opinion
+- Jaakko: no strong opinion, we should only use one
+- Hafliði: I won’t miss Slack, not used it much anyhow
+- Tuuli: no strong opinion on this, Slack is ok, but problem is if messages are disappearing
+- Samis vote will decide: Let's start using Gitter on the side, but prefer to use the mailing list as the main discussion channel. This way we can avoid loosing messages
+
+## Other issues
+
+Marko Kauppi has started to work at Ubigu Ltd full time, transition period with city of Tampere still on the way regarding Oskari maintenance
+
+NLS-IS: There has been lot of changes in metadata (GeoNetwork), new applications coming up, but not much Oskari related stuff happening this year
+
+NLS-FI: new release coming just around the corner, maybe next week. Vector tile support will be in the job list after that. 
+
+Helsinki: Jussi said that City of Helsinki has now been consentrating on metadata issues and they will now be automatically updated to national metadataservice, after that maybe some Oskari handling. Discussed a little bit about Ckan-Oskari compatibility and that there is a need for test how Oskari can handle interfaces from Ckan. Sanna will continue chatting with this issue with Jussi via email-list. This is something that interesets those who have dataportal and Oskari instance, like Lounaistieto.fi for instance. 
+
+## Next meeting
+
+Next meeting: 9.10.2018, scheduled now every month, every second week tuesday at 15:00 (GMT+3)
+
+## End of meeting: 15:56

--- a/_content/blog/2018-09-11-PSC_September_2018.md
+++ b/_content/blog/2018-09-11-PSC_September_2018.md
@@ -4,7 +4,7 @@ title:  "OSGeo PSC - September meeting 2018"
 excerpt : "New roadmap items were approved, new OIP"
 date:   2018-09-11 15:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # September meeting 2018

--- a/_content/blog/2018-09-11-PSC_September_2018.md
+++ b/_content/blog/2018-09-11-PSC_September_2018.md
@@ -4,6 +4,7 @@ title:  "OSGeo PSC - September meeting 2018"
 excerpt : "New roadmap items were approved, new OIP"
 date:   2018-09-11 15:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # September meeting 2018

--- a/_content/blog/2018-10-09-PSC_October_2018.md
+++ b/_content/blog/2018-10-09-PSC_October_2018.md
@@ -4,7 +4,7 @@ title:  "OSGeo PSC - October meeting 2018"
 excerpt : "New roadmap items were approved, new OIP"
 date:   2018-10-09 15:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # October meeting 2018

--- a/_content/blog/2018-10-09-PSC_October_2018.md
+++ b/_content/blog/2018-10-09-PSC_October_2018.md
@@ -1,0 +1,91 @@
+---
+layout: post
+title:  "OSGeo PSC - October meeting 2018"
+excerpt : "New roadmap items were approved, new OIP"
+date:   2018-10-09 15:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# October meeting 2018
+
+The PSC gathered to discuss the following agenda:
+
+- New roadmap items
+- React
+- Ideas for joint development
+- Vector tile tests
+- Activity of PSC members
+
+## Opening the meeting at 15:05
+
+Via conference call:
+
+- Sami Mäkinen
+- Jaakko Ruutiainen
+- Timo Sallinen
+- Tuuli Pihlajamaa
+- Marko Kuosmanen
+- Jussi Arpalahti
+- Heikki Ylitalo
+- Sanna Jokela (secretary)
+
+Not present:
+- Tomi Lukkarinen
+- Hafliði Sigtryggur Magnússon
+
+## New roadmap items
+
+No new ones since last meeting.
+
+## OIP
+
+Approvement of OIP: Layer permission handling, got 8 up-votes and is now approved
+
+## React discussion
+
+It was discussed that from now on all new bundles should be done with React, no new OIPs will be approved if they are not done with React. Old features are still in Jquery and should be converted to React bundle at a time. This will be a long process. You can still use Jquery based bundles with React bundles.
+Sami adds a new OIP on this: React is the initial way to create new bundles for the PSC to approve.
+
+It was also noted that the use of React can bring global interest in the Oskari development.
+
+Map legend could be the first to be changed from Jquery to React
+
+ES6/Babel.js was also discussed and both are used in Oskari 1.49.0+
+
+Just to clarify, it was asked what are the differences in core and community bundle: 
+- Core: all the things that are tested and approved 
+- Community Bundle: are not tested with version updates, those who are responsible of their development should keep up with the versioning.
+
+## Draft ideas from Oskari Developer Summit
+
+Wizards could be interesting to have in Oskari (in admin side & end user side) to make functionalities more accessible for users.
+
+Installation guide would be nice (form stating what are the tailored features, guide for creating the installation). This needs more information & concept models.
+
+We need good quality demo datasets for demo.oskari.org (this task was delegated to Oskari Joint Development Forum).
+
+Usability research & development of UI could be the next big thing to do for Oskari together.
+
+Modularity in all Oskari work was regarded a good thing in the summit.
+
+We also need a list for supported standards, this needs better documentation & admin side development.
+
+Do we have needs for linked data support? Geosparql tests are needed (Statistics Finland & NLS-FI might be checking into this).
+
+Help for end users: creation of tooltips / error messages was needed. This is ongoing work and part of better documentation and development.
+
+## Other issues
+
+WFS-T support needs improvement and maybe joint development efforts.
+
+Vector tile tests are done currently in NLS-FI, possibility to cache. Frontend has an overall vector tile support, can be seen in demo.paikkatietoikkuna.fi, Sami would like to have the background datasets in demo.oskari.org as vector tiles.  
+
+## Activity of the PSC-members
+
+What to do if some members are not active? It was decided to message them in person and ask if they still want to be part of PSC.
+
+## Next meeting
+
+Next meeting: 13.11.2018, scheduled now every month, every second week tuesday at 15:00 (GMT+3)
+
+## End of meeting: 15:44

--- a/_content/blog/2018-10-09-PSC_October_2018.md
+++ b/_content/blog/2018-10-09-PSC_October_2018.md
@@ -4,6 +4,7 @@ title:  "OSGeo PSC - October meeting 2018"
 excerpt : "New roadmap items were approved, new OIP"
 date:   2018-10-09 15:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # October meeting 2018

--- a/_content/blog/2018-11-13-PSC_November_2018.md
+++ b/_content/blog/2018-11-13-PSC_November_2018.md
@@ -4,7 +4,7 @@ title:  "OSGeo PSC - November meeting 2018"
 excerpt : "PSC members, community repository, news"
 date:   2018-11-13 15:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # November meeting 2018

--- a/_content/blog/2018-11-13-PSC_November_2018.md
+++ b/_content/blog/2018-11-13-PSC_November_2018.md
@@ -1,0 +1,86 @@
+---
+layout: post
+title:  "OSGeo PSC - November meeting 2018"
+excerpt : "PSC members, community repository, news"
+date:   2018-11-13 15:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# November meeting 2018
+
+The PSC gathered to discuss the following agenda:
+
+- Follow up from last meeting 
+- News from the PSC members
+- New roadmap items
+- Community repository
+- Documentation improvement
+
+## Opening the meeting at 15:04
+
+Via conference call:
+
+- Sami Mäkinen
+- Jaakko Ruutiainen
+- Timo Sallinen
+- Tuuli Pihlajamaa
+- Marko Kuosmanen
+- Sanna Jokela (secretary)
+
+Not present:
+- Jussi Arpalahti
+- Tomi Lukkarinen
+- Hafliði Sigtryggur Magnússon
+- Heikki Ylitalo
+
+## Last meeting topics and follow-up
+
+- New roadmap items: Approvement of OIP: Layer permission handling (still under way - NLS-FI responsible)
+- React-discussion (no new bundles on the way, Sami will add OIP on this: new functionality should be created using React)
+- Draft ideas from Oskari Developer Summit (Sanna will add ideas to GitHub asap)
+- Vector tile tests (No new development on this, idea: example solution for demo.oskari.org using OpenTileMaps, it has some issues on performance)
+- Activity of PSC members (Lukkarinen wants to stay in the PSC, time of the meetings is not possible for him, suggested that at 13:00 should be better ⇒ let’s change this, Sanna will update the calendar invitations)
+
+## News from the PSC members
+
+- Jaakko: Liiteri-service by Environmental Centre of Finland (hiearchical layer update) & Finnish Heritage Agnecy (download basket) have some development issues and updates on the way, no new bigger development tasks. 
+- Marko: Download basket PR, openlayer 5 +, requests how to download datasets is under research (now download link is send to email and causes timeout if the package is too large)
+- Sanna: Training ideas on Oskari are developed with Gispo Ltd & Ubigu Ltd. Turku University of Applied Science students are doing some UI chekups and useability research on different Oskari-cases, the research should be ready on 5.12.2018. Website-development is crucial: oskari.org mockup for the website has been done. Development in 2019 (JDF is budgeting on this about 5000€).
+- Timo S: Students are going to make UI tests on Suomi.fi-maps. Community repo setup is now its own repository. Long term roadmap for issues is being developed. Open311 support one of the issues. Environmental Centre has has some ideas on how to collect POIs with Suomi.fi-maps
+- Tuuli: Student are also testing the needs of Statistics Finland and Oskari. Ideas are been developed on Sparql - linked data solution, query language is near SQL. New map layer type could be the solution, admin could add that layer to Oskari? New version of the idea will be drafted and think about how it will be used in Oskari for the end user. 
+- Sami: Lots of front code re-organisation has been going on. Front end: deletion of application specific functions (ELF, ArcticSDI, etc.). New: contrib repo has been created (=community repository) which now holds most of the unsupported and/or application specific functionality that was previously in oskari-frontend. Paikkatietoikkuna: acts as an example for using app-specific repository that uses code from both contrib and oskari-frontend. Oskari is now more lean and nice. How version publication will be made in contrib side - is it enough to have a git tag for release synced with oskari-frontend release? Now in contrib repo: analysis, content editor tools, etc. Next release 1.49 has the new structure (possibly in the end of this month). 1.50 (Jetty 9 packaging). Any ideas on this? Jetty 8 ⇒ Jetty 9 documentation? Documentation could be versioned in the future? Let’s add this as a Website development issue
+
+
+## New roadmap items
+
+- Oskari website & documentation development plan should be added to GitHub (Sanna can do this)
+- Liiteri ESRI Rest support development (can be found from Sitowise GitHub, Liiteri branch), usefull if someone has ArcGISServer in use
+
+
+## OIP
+
+- no new ones to discuss/approve.
+
+## Community repository
+
+- Repository changes: community repository has been launched: https://github.com/oskariorg/oskari-frontend-contrib 
+
+## PSC members
+
+- Heikki Ylitalo has stated that he will step down from Oskari PSC due to a new job. Sami asks that he should state this also through Oskari mailing list.
+- Timo Aarnio has had interest in joining PSC
+- Everybody can also suggest new people to the PSC
+
+## Documentation improvement 
+
+- Work is ongoing and Oskari.org structure development coming up in 2019. 
+- Feedback from the audience, the set-up documentation needs to be created for different environments - this should be documented when new installations are made so that all different elements are somehow reported. 
+- Question from JDF: are there good instructions available for how to maintain community bundles and when to update Oskari?
+- When the updating is “risk free” meaning when Oskari is already updated by some other. It was stated by Sami that latest version should always be the best.
+- LTR-stamp issue was discussed. Should we have fixed schedule with Oskari? It was decided to get back to this in the next meeting. 
+
+## Next meeting
+
+Next meeting: 11.12.2018, scheduled now every month, every second week tuesday at 13:00 (GMT+3). NEW TIME!
+
+## End of meeting: 16:07

--- a/_content/blog/2018-11-13-PSC_November_2018.md
+++ b/_content/blog/2018-11-13-PSC_November_2018.md
@@ -4,6 +4,7 @@ title:  "OSGeo PSC - November meeting 2018"
 excerpt : "PSC members, community repository, news"
 date:   2018-11-13 15:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # November meeting 2018

--- a/_content/blog/2018-12-11-PSC_December_2018.md
+++ b/_content/blog/2018-12-11-PSC_December_2018.md
@@ -4,6 +4,7 @@ title:  "OSGeo PSC - December meeting 2018"
 excerpt : "News, new release"
 date:   2018-12-11 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # December meeting 2018

--- a/_content/blog/2018-12-11-PSC_December_2018.md
+++ b/_content/blog/2018-12-11-PSC_December_2018.md
@@ -1,0 +1,64 @@
+---
+layout: post
+title:  "OSGeo PSC - December meeting 2018"
+excerpt : "News, new release"
+date:   2018-12-11 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# December meeting 2018
+
+The PSC gathered to discuss the following agenda:
+
+- Last meetings topics
+- News from the members
+
+## Opening the meeting at 13:07
+
+Via conference call:
+- Sami Mäkinen
+- Jaakko Ruutiainen
+- Timo Sallinen
+- Tuuli Pihlajamaa
+- Marko Kuosmanen
+- Sanna Jokela (secretary)
+
+Not present:
+- Marko Kauppi
+- Tomi Lukkarinen
+- Jussi Arpalahti
+- Hafliði Sigtryggur Magnússon
+
+## Last meeting topics and follow-up
+
+Download basket: updates & requests for downloading under research
+
+Turku University of Applied Science students have made usability research on Oskari (Suomi.fi maps, Paikkatietoikkuna / Statistics Finland needs and Oskari.org documentation). Documentation from the projects have been sent to the responsible parties, Sanna can do a summary of them in English. 
+
+Discussion about when to take new Oskari version in use and instructions for updating community bundles. LTR-thinking needs funding - who is responsible? New release is updated always in Paikkatietoikkuna, Elf & ArcticSDI, but e.g. Tampere has still a year old version. Documentation / instructions: newest release is always the best (Sanna willl add this to the community-pages) 
+
+Oskari website & documentation development plan https://github.com/oskariorg/oskari-docs/issues/82
+
+Liiteri ESRI Rest support development ⇒ GitHub (Kuosmanen asks Olli) 
+
+## New roadmap items 
+
+Not at this moment
+
+## News from the members
+
+New Oskari release available 1.49, 1.50 is being released probably this week (library updates & Jetty). 1.51 milestones are available in GitHub. 
+- Some problems with Thematic Maps legend, probably one hot fix coming up soon
+- Jetty 9 is being updated in NLS-FI, also Kuosmanen has tested (works nice). 
+
+5000€ for website development is being allocated in the next year  by JDF (Joint Development Forum)
+
+Statistics Finland Oskari instance is being updated to newest version soon
+
+Suomi.fi maps roadmap is under way 
+
+## Next meeting
+
+Next meeting: 8.1.2019, scheduled now every month, every second week tuesday at 13:00 (GMT+3)
+
+## End of meeting: 13:32

--- a/_content/blog/2018-12-11-PSC_December_2018.md
+++ b/_content/blog/2018-12-11-PSC_December_2018.md
@@ -4,7 +4,7 @@ title:  "OSGeo PSC - December meeting 2018"
 excerpt : "News, new release"
 date:   2018-12-11 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # December meeting 2018

--- a/_content/blog/2019-01-07-Oskari_RPC_Ubigu.md
+++ b/_content/blog/2019-01-07-Oskari_RPC_Ubigu.md
@@ -1,0 +1,49 @@
+---
+layout: post
+title:  "What is Oskari RPC?"
+excerpt : "Oskari API is a really nice option for creating light weight map services"
+date:   2019-01-09 13:00:00 +0300
+categories: [news]
+---
+
+# Why choose Oskari API over Oskari installation?
+
+In 2018 I requested Marko Kauppi from Ubigu Ltd to describe where he sees Oskari should be going in the future and he replied:
+
+_"It would be interesting to see more services that utilizes Oskari’s API which is created with RPC technology."_
+
+So let’s go into the realm of the elusive RPC a little bit. 
+Oskari setups are usually quite extensive with lots of different datasets and tools (check out for example [Liiteri - service for environmental information](https://liiteri.ymparisto.fi/) or [Regional information service in SW Finland](http://karttapalvelu.lounaistieto.fi/)).
+
+But then there are services focusing on only one theme, like for example [Fishing restrictions](https://kalastusrajoitus.fi/) which 
+offers the possibility for their users to check what are the fishing limitations in a requested area. 
+City of Tampere offers a [feedback service for tram planning](https://kartat.tampere.fi/raitiotieallianssi/) and National Land Survey of Finland has their own lean client interface called [Mapsite](https://asiointi.maanmittauslaitos.fi/karttapaikka/?lang=en). As we have told you before, Kela (Social Insurance Institute) recently opened their service for [finding your nearest social service point](https://oskari.org/gallery/kela) and GI learning portal [PaikkaOppi was renewed](https://oskari.org/gallery/paikkaoppi).
+
+They are all examples of utilizing Oskari API.
+
+## If you do not have the resources to setup your own Oskari instance 
+
+Take ruthlessly advantage of those offering the published maps functionality. You can use the service provided by say [Suomi.fi maps](https://verkosto.oskari.org/en/suomi_fi/) or [Paikkatietoikkuna](http://www.paikkatietoikkuna.fi/) and create an embedded map and customize it with available RPC tools. This way you can enhance and modify the map service and make it talk to your own site.
+
+RPC actually means [Remote Procedure Call](https://en.wikipedia.org/wiki/Remote_procedure_call) - so retrieving tools to a client from a service providing this technology. 
+The map in the examples are created with some already existing Oskari installation and RPC is a way for the website to talk with the embedded map 
+and request needed functionalities from the master Oskari installation.
+
+RPC tech is now being tested in several other services as well; 
+Finnish Heritage Agency has stated that they are currently developing a map service for [reporting archeological findings](https://verkosto.oskari.org/en/reporting-archaeological-findings-with-rpc/) with 
+RPC and Helsinki Region Environmental Services Authority (HSY) are creating a climate atlas with Oskari API.
+
+## RPC use is spreading
+
+This is something that also Ubigu Ltd is looking for.
+
+_"I hope that Oskari could be easily tailored to different map needs from functionality to visual appearance"_, continues Kauppi.
+
+Maybe RPC could be the solution?
+
+Here are some tips [for developers](https://github.com/oskariorg/rpc-client) to use RPC technology and the [request examples](http://oskari.org/examples/rpc-api/rpc_example.html).
+
+Thanks for the comments Marko, and let's hope that we will see more Oskari API examples this spring!
+
+Story by Sanna Jokela,
+Oskari communication coordinator

--- a/_content/blog/2019-01-07-Oskari_RPC_Ubigu.md
+++ b/_content/blog/2019-01-07-Oskari_RPC_Ubigu.md
@@ -4,7 +4,7 @@ title:  "What is Oskari RPC?"
 excerpt : "Oskari API is a really nice option for creating light weight map services"
 date:   2019-01-09 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Why choose Oskari API over Oskari installation?

--- a/_content/blog/2019-01-07-Oskari_RPC_Ubigu.md
+++ b/_content/blog/2019-01-07-Oskari_RPC_Ubigu.md
@@ -4,6 +4,7 @@ title:  "What is Oskari RPC?"
 excerpt : "Oskari API is a really nice option for creating light weight map services"
 date:   2019-01-09 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Why choose Oskari API over Oskari installation?

--- a/_content/blog/2019-01-08-Highlights_of_Oskari_2018.md
+++ b/_content/blog/2019-01-08-Highlights_of_Oskari_2018.md
@@ -4,6 +4,7 @@ title:  "Highlights of Oskari in 2018"
 excerpt : "These were the highlights of the year 2018 for Oskari"
 date:   2019-01-08 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Highlights of Oskari in 2018

--- a/_content/blog/2019-01-08-Highlights_of_Oskari_2018.md
+++ b/_content/blog/2019-01-08-Highlights_of_Oskari_2018.md
@@ -4,7 +4,7 @@ title:  "Highlights of Oskari in 2018"
 excerpt : "These were the highlights of the year 2018 for Oskari"
 date:   2019-01-08 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Highlights of Oskari in 2018

--- a/_content/blog/2019-01-08-Highlights_of_Oskari_2018.md
+++ b/_content/blog/2019-01-08-Highlights_of_Oskari_2018.md
@@ -1,0 +1,56 @@
+---
+layout: post
+title:  "Highlights of Oskari in 2018"
+excerpt : "These were the highlights of the year 2018 for Oskari"
+date:   2019-01-08 13:00:00 +0300
+categories: [news]
+---
+
+# Highlights of Oskari in 2018
+
+New Oskari community year starting, these were the highlights of Oskari in year 2018!
+
+Not in any particular order, but here are 8 of the best things happened in Oskari community! Share yours in Twitter with @oskari_org.
+
+## 1. Downloading data from Oskari became possible
+
+Download basket offers the possibility to download datasets - first Oskari community bundle was released! With the download functionality you can select an area on the map based on free drawing or existing borders and download the chosen datasets that intersect the area. Download possibility is a community built plugin for Oskari and it has been taken in use in many Oskari instances.
+
+## 2. Map layers are now in order
+
+Oskari has now a core functionality which allows the possibility to provide hierarchies to map layers. And it is also the first ever tool in Oskari core that was created by several organisations' joint development efforts! Previously map layers could be handled only inside one theme, but now they can belong to several map hierarchies (like bicycling routes can be shown in "Tourism", "Sports" and "Networks" themes). Also the user interface was developed further to save space in the layer handling by adding the chosen layers into a separate tab.
+
+## 3. Choropleth maps - you can do it!
+
+Thematic maps is a core Oskari feature that has the ability to create choropleth maps from statistical interfaces. This tool among others was renewed in spring 2018 and it combines statistics and maps quite neatly. Now you can also create point symbol maps (proportional symbol maps) from statistical data related to areas. You can also view the data through bar charts and sort the attribute table more easier. The layout has been lightened so that the opening windows do not cover the maps as much as it did before.
+
+At the same time the Time Series Tool and Terrain profile tools (WCS-service support) was taken in use.
+
+## 4. Start crowdfunding Oskari
+Oskari community wanted to start promoting crowdfunding for Oskari projects. Some of the needed Oskari tools are community inspired and might gain funding from several instances. Start your crowdfunding campaign today! Oskari community provides the process and helps you with the marketing.
+
+## 5. Active Oskari community grows
+
+Already 38 organisations in Oskari community together with 10 Joint Development Forum members. In the spring 2018 we also experienced an unexpected voting frenzy for new organisational members to the board with over 700 votes 🙂
+
+In 2018 Oskari projects went onward and released new tools and fixes to Oskari. Some of the projects have just recently established. The biggest news was that Statistics Finland starts using Oskari as their map platform. The announcement was made in EFGS conference held in Helsinki in October and it is line with the EFGS's mission to combine statistics and geography - this Oskari does very well.
+
+## 6. More open development
+
+Oskari PSC (Project steering committee) has been actively meeting and GitHub usage has steadily grown. We are also eager to get more developers to take Oskari in use and we are happy to see that new organisations and members are starting to join in!
+
+Oskari is in the OSGeo Incubation process and OSGeo Incubation Committee craved for more open communication from Oskari. So Oskari totally opened up its discussion channels: Gitter and User mailing list are now in active use. As the Godfather of Oskari - Timo Aarnio said in FSFE interview: "Go open today, there's no excuse not to".
+
+## 7. New use cases on Oskari API
+
+During the year we have seen lots of good use cases on Oskari API. The Social Insurance Institution of Finland took Oskari API in use in the fall 2018 and almost at the same time GIS education portal PaikkaOppi turned 10 years and Oskari based. PaikkaOppi has been pioneering the use of open source in GIS education. In 2018 PaikkaOppi started to use Oskari API and tailored contents to bring GIS learning more approachable for kids in schools.
+
+This inspired us to collect all the known Oskari API examples together. Tell us yours!
+
+## 8. Lovely Oskari Otter in the field 
+
+Last but not least. Oskari Otter traveled his way into people's hearts in Twitter<3! We had the privilege to start working with Oskari Otter - a laid back full stack developer who has been living most of his life in the basement of National Land Survey of Finland enjoying his share of fish and chips. In the fall 2018 Oskari Otter blew the roof and became the ambassador of open source. Now he travels everywhere Oskari software goes. If you see him, be sure to take a picture and tag him #oskariotter.
+
+<img src="/img/oskari_otter_tre.jpeg" width="300" class="img-responsive"/>
+
+

--- a/_content/blog/2019-01-08-PSC_January_2019.md
+++ b/_content/blog/2019-01-08-PSC_January_2019.md
@@ -4,7 +4,7 @@ title:  "Plans for 2019 - January meeting 2019"
 excerpt : "Updates going on, Oskari Dockerization, metadata integration, process for receiving new issues from GitHub, vector tiles, complex WFS"
 date:   2019-01-08 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # January meeting 2019

--- a/_content/blog/2019-01-08-PSC_January_2019.md
+++ b/_content/blog/2019-01-08-PSC_January_2019.md
@@ -4,6 +4,7 @@ title:  "Plans for 2019 - January meeting 2019"
 excerpt : "Updates going on, Oskari Dockerization, metadata integration, process for receiving new issues from GitHub, vector tiles, complex WFS"
 date:   2019-01-08 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # January meeting 2019

--- a/_content/blog/2019-01-08-PSC_January_2019.md
+++ b/_content/blog/2019-01-08-PSC_January_2019.md
@@ -1,0 +1,94 @@
+---
+layout: post
+title:  "Plans for 2019 - January meeting 2019"
+excerpt : "Updates going on, Oskari Dockerization, metadata integration, process for receiving new issues from GitHub, vector tiles, complex WFS"
+date:   2019-01-08 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# January meeting 2019
+
+The PSC gathered to discuss the following agenda:
+
+- Last meetings topics
+- News from the members
+- Highlight of 2018
+- Oskari tasks for 2019
+
+## Opening the meeting at 13:05
+
+Via conference call:
+
+- Sami Mäkinen
+- Jaakko Ruutiainen
+- Timo Sallinen
+- Tuuli Pihlajamaa
+- Marko Kuosmanen
+- Marko Kauppi
+- Tomi Lukkarinen
+- Jussi Arpalahti
+- Hafliði Sigtryggur Magnússon
+
+- Sanna Jokela (secretary)
+
+Not present: X
+
+## Last meeting topics and follow-up
+
+New Oskari 1.49 and 1.50 were released in December. Sami will inform Oskari mailing list about the 1.50.
+
+Jetty 9 installation going on at the moment in different setups in NLS-FI.
+
+Website development has received 5000€ funding from JDF. It was discussed that the possible different solutions should be checked (readthedocs, mkdocs, WordPress/GitHub integration like https://www.dreamhost.com/blog/using-git-wordpress/). E.g. GeoNode uses documentation from GitHub: http://docs.geonode.org/en/latest/index.html   
+
+Statistics Finland Oskari instance is being updated to 1.49 version - update of the user guide coming up soon.
+
+Suomi.fi maps roadmap is under way but no concrete roadmap issues yet available.
+
+## News from the members
+
+Hafliði: Oskari upgrading should be done for the NLS-IS in the spring. People are interested in the statistics part and there is pressure to have this up and running.
+
+Jaakko: No Oskari related news.
+
+Jussi: Plans for creating Docker images for Oskari. It was discussed that the new Jetty has changed the installation a bit but the documentation has been updated. Jussi promised to test this. Also INSPIRE metadata inspection with Helsinki metadata has been inspected. Jussi will show something on this in the future. Geonode uses http://pycsw.org for metadata to convert own metadata to OGC metadata, CKAN etc.
+
+Marko Kauppi: Oskari migration is being done for City of Tampere at the moment, current authentication with SAML will be replaced with another one.
+
+Marko Kuosmanen: Liikennevirasto Jetty 9 upgrade ongoing. NBA Oskari 1.49 update, Liiteri 1.49 upgrade coming with hierarchical layerlist.
+
+Timo: At the moment updating installation scripts and pipelines for Suomi.fi maps. Suomi.fi maps roadmap is being updated and the list is quite long. Planning to have input round from customers. Most issues are already in Oskari roadmap, maybe some new issues are going to be common. 
+
+Tuuli: Nothing to add to the previous, no publication date available yet for the Statistics Finland Oskari installation.
+
+Tomi: Version upgrades and small improvements (visual fixes) coming up in HSY. There are many projects in HSY using Oskari and RPC use is growing this year. HSY is working with Sitowise to achieve these. Many small improvements are still waiting for the right project. Some of the ideas could be also valuable for the Oskari community. ==> We need a process to get those ideas to GitHub. Timo will talk to HSY people about this.
+
+Sami: New Jetty 9-based servers are being installed. New version of the RPC client just came up. It has a new helper function for React-based apps/state engines. Documentation can be found on the RPC-client repo. We are now testing how to create Vector tiles from WFS (big development effort). This is something that could replace the Transport webapp on Oskari. Transport has an advantage with enabling complex WFS to be used - which is a selling point for Oskari. Also printing of WFS-features and some other functionalities have not been developed for this yet. Link to a demo page where you can test the new WFS -> vector tiles functionality using the new backend (instead of transport webapp): https://demo-kartta.paikkatietoikkuna.fi/?uuid=1e03a73e-a50e-41fd-b3c0-9bd5b3dafe35 
+
+## PSC members
+
+Jaakko Ruutiainen is stepping down from the PSC due to change of workplace.
+
+## New roadmap issues
+
+Improvement of the documentation site https://github.com/oskariorg/oskari-docs/issues/82 was approved.
+
+## Other issues
+
+Highlights in 2018:
+https://verkosto.oskari.org/en/highlights-in-oskari-community-in-2018/ 
+New Thematic maps functionality could be listed also (let’s add this, Sanna has to do an article about it first).
+
+2019 biggest steps for Oskari
+- Plans for 3D map engine
+- Vector tiles
+- My places & user layers merge (possibly)
+- More and more React bundles
+
+Just as a reminder, PSC instant chat is in Gitter: https://gitter.im/oskariorg/psc 
+
+## Next meeting
+
+Next meeting: 12.2.2019, scheduled now every month, every second week tuesday at 13:00 (GMT+3)
+
+## End of meeting: 13:59

--- a/_content/blog/2019-02-19-PSC_February_2019.md
+++ b/_content/blog/2019-02-19-PSC_February_2019.md
@@ -4,6 +4,7 @@ title:  "February meeting 2019"
 excerpt : "Ansible & redhat scripts, news, discussion of layer external info-tool"
 date:   2019-01-08 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # February meeting 2019

--- a/_content/blog/2019-02-19-PSC_February_2019.md
+++ b/_content/blog/2019-02-19-PSC_February_2019.md
@@ -1,0 +1,85 @@
+---
+layout: post
+title:  "February meeting 2019"
+excerpt : "Ansible & redhat scripts, news, discussion of layer external info-tool"
+date:   2019-01-08 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# February meeting 2019
+
+The PSC gathered to discuss the following agenda:
+
+- Last meetings topics
+- News from the members
+- Layer external info url and description-issue
+- Oskari workshop and Oskari day
+
+## Opening the meeting at 13:04
+
+Via conference call:
+
+- Sami Mäkinen
+- Timo Sallinen
+- Tuuli Pihlajamaa
+- Jussi Arpalahti
+
+- Sanna Jokela (secretary)
+
+Not present:
+- Marko Kuosmanen
+- Marko Kauppi
+- Tomi Lukkarinen
+- Hafliði Sigtryggur Magnússon
+
+## Last meeting topics and follow-up
+
+Improvement of the documentation site was approved: https://github.com/oskariorg/oskari-docs/issues/82  
+
+Highlights in 2018 and tasks for 2019 were discussed
+
+## News from the members
+
+Sami: 
+- WFS3 support, complex feature parsing in development (using NLS-FI name database as example service)
+- Bing maps support added (requires an API key for an Oskari instance to use)
+- Thematic map legend is being converted from jQuery to React
+- New tool for describing Oskari database schema: html-site generated from the database to oskari.org
+- Ansible scripts for installing Oskari Jetty 9 can be found in https://github.com/oskariorg/sample-configs/tree/master/ansible/jetty9-install
+
+Jussi:
+- Oskari tests with Helsinki historical maps maybe coming up (Helsinki City Archives)
+- Metadata: Geonetwork implementation, interface for downloading standard geospatial metadata needed. Work is on-going.
+- Helsinki service map being rewritten with React - There could be some co-operation designing/implementing the Openlayers React wrapper as Oskari could possibly use the same component? Meetup/workshop? Jussi can ask and arrange this.
+
+Tuuli: 
+- nothing to announce
+
+Timo: 
+- bug tests with newest version
+- redhat linux rpm package installation model scripts are available if someone has interest (front code, jetty installation, transport and server web app). Jussi is interested, Timo will send the scripts.
+
+Sanna: 
+- workshop for Oskari maybe coming up, arranged by Ubigu & Gispo
+- Oskari Day TBA, maybe April-May
+- Gispo done some tests with Oskari RPC, thanks for the help in Gitter!
+
+
+## New roadmap issues
+
+Layer external info url and description: https://github.com/oskariorg/oskari-docs/issues/96 
+
+Issue was discussed and there was some reservations about does this need to be part of Oskari. Also at the same time we should think if Oskari should be driven towards content management system side. It was decided that all PSC members should go through the proposal and it is to be voted after that. Due date for decision is 26th of February.
+ 
+
+## Other issues
+
+- Gitter has been active, which is nice! Rocketchat PSC channel has been removed permanently in favor of Gitter.
+- Java 11 support - pull requests are now compiled with 3 JDKs: Oracle 8, OpenJDK 8 and Oracle 11
+- Code analysis tool: spot bugs added to Oskari https://github.com/oskariorg/oskari-server/pull/320, but not yet used on PRs
+
+## Next meeting
+
+Next meeting: 12.3.2019, scheduled now every month, every second week tuesday at 13:00 (GMT+3)
+
+## End of meeting: 13:50

--- a/_content/blog/2019-02-19-PSC_February_2019.md
+++ b/_content/blog/2019-02-19-PSC_February_2019.md
@@ -4,7 +4,7 @@ title:  "February meeting 2019"
 excerpt : "Ansible & redhat scripts, news, discussion of layer external info-tool"
 date:   2019-01-08 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # February meeting 2019

--- a/_content/blog/2019-03-12-PSC_March_2019.md
+++ b/_content/blog/2019-03-12-PSC_March_2019.md
@@ -1,0 +1,90 @@
+---
+layout: post
+title:  "March meeting 2019"
+excerpt : "Oskari community day, React, styling libraries, GeoNode comparison, news"
+date:   2019-03-12 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# March meeting 2019
+
+The PSC gathered to discuss the following agenda:
+
+- Last meetings topics
+- News from the members
+- Styling libraries tests
+- Oskari community day
+
+## Opening the meeting at 13:04
+
+Via conference call:
+
+- Sami Mäkinen
+- Marko Kuosmanen
+- Marko Kauppi
+- Jussi Arpalahti
+- Sanna Jokela (secretary)
+
+Not present:
+
+- Tomi Lukkarinen
+- Hafliði Sigtryggur Magnússon
+- Timo Sallinen
+- Tuuli Pihlajamaa
+
+## Last meeting topics and follow-up
+
+Layer external info url and description: https://github.com/oskariorg/oskari-docs/issues/96
+
+- Comments have been made to the issue by PSC members, but implementation is at the moment postponed and issue is closed for now
+
+Rocketchat PSC channel is no longer in use, use Gitter only
+
+## Oskari Community Day 25.4.2019 in Helsinki
+
+Remember to sign up: https://www.meetup.com/Oskari-Your-geospatial-friend/events/259264054/. 
+
+Morning session is about Oskari use cases and on the afternoon there will be a mini hackfest were you can ask things from the developers or do bug fixes and other contributing actions. 
+
+## News from the members
+
+Jussi: 
+- Oskari Dockerization progressing, scripts available in https://github.com/jussiarpalahti/oskariexp - some finance issues to be tackled
+
+Sami: 
+- Map layer admin with React is being implemented. Starting out by wrapping https://ant.design/ components as Oskari UI components.
+- Some coding guidelines are being tested out: 
+-- named instead of default exports
+-- common convention for hiding elements from the UI
+-- lots more files in React implementation: how to structure the files in folders so things can be found easily.
+-- Context to be used as a way to share localization and services throughout React composition
+-- service classes to possibly have getMutator() type of function that is handed to the context so instead of getters the data is passed through component props.
+- Documentation has been improved and structure of the pages is being enhanced by creating better request descriptions and navigation. Bundle documentation is to be tied more tightly to functionalities.
+- Also new bundle architecture is being implemented, take a look at  http://oskari.org/guides/modern-bundle  
+- Styling libraries are being tested at the moment in NLS-Fi. Component level styles to be renewed due to changing to use React. Currently trying out https://www.styled-components.com/ for component level styling. The majority of styles are still processed from SCSS files. When most things are in React we will think about using something else to get rid of Python dependency. Less, Stylus, etc. libraries are being checked by NLS-FI. Tests are conducted first and then OIP for the common guidelines when we have more experience what to recommend.
+
+Marko Kuosmanen: 
+- HSY Oskari service has been updated with Jetty & Oskari 1.50
+
+Marko Kauppi: 
+- Tampere has a new authentication setup for Oskari (replacing the old SAML one) and tests are being made at the moment
+- New download service is being created in Tampere - at the moment it is for Tampere use but could become a community bundle. It will have an Admin UI to help the adminstrators of the service. It will allow linking downloadable files for vector features, because e.g. drone images are still in file system and the amount of files is growing all the time. Download service will have a new UI for end users also.
+
+Sanna: 
+- Gispo & Ubigu will be holding an Oskari training on 24.4.2019 at Helsinki (configuring Oskari setup from clean installation). Docker image was discussed for the training purpose. More info coming up soon.
+- Sanna wanted to know is GeoNode a challenger for Oskari? GeoNode is being used in large multinational organisations and been integrated with QGIS also, so usage is probably growing. It was discussed that we could do an article on the differences between Oskari and GeoNode. Oskari is a map service which can produce new map services. GeoNode is a content management system. So they have slightly different approaches. Also GeoNode stores the GIS information in itself and probably needs to support QGIS because of this. Oskari on the other hand builds on distributed spatial data infrastructure and doesn't really store the GIS information on itself. It was also seen crucial for gaining more users that companies would take Oskari as a tool and market it also globally.
+
+## New roadmap issues
+
+- no new issues 
+
+## Other issues
+
+- no other issues
+
+
+## Next meeting
+
+Next meeting: 9.4.2019, scheduled now every month, every second week tuesday at 13:00 (GMT+3)
+
+## End of meeting: 13:56

--- a/_content/blog/2019-03-12-PSC_March_2019.md
+++ b/_content/blog/2019-03-12-PSC_March_2019.md
@@ -4,6 +4,7 @@ title:  "March meeting 2019"
 excerpt : "Oskari community day, React, styling libraries, GeoNode comparison, news"
 date:   2019-03-12 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # March meeting 2019

--- a/_content/blog/2019-03-12-PSC_March_2019.md
+++ b/_content/blog/2019-03-12-PSC_March_2019.md
@@ -4,7 +4,7 @@ title:  "March meeting 2019"
 excerpt : "Oskari community day, React, styling libraries, GeoNode comparison, news"
 date:   2019-03-12 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # March meeting 2019

--- a/_content/blog/2019-04-09-PSC_April_2019.md
+++ b/_content/blog/2019-04-09-PSC_April_2019.md
@@ -4,7 +4,7 @@ title:  "April meeting 2019"
 excerpt : "Oskari community day, Oskari dockerization, WFS 3 client, news"
 date:   2019-04-09 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # April meeting 2019

--- a/_content/blog/2019-04-09-PSC_April_2019.md
+++ b/_content/blog/2019-04-09-PSC_April_2019.md
@@ -4,6 +4,7 @@ title:  "April meeting 2019"
 excerpt : "Oskari community day, Oskari dockerization, WFS 3 client, news"
 date:   2019-04-09 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # April meeting 2019

--- a/_content/blog/2019-04-09-PSC_April_2019.md
+++ b/_content/blog/2019-04-09-PSC_April_2019.md
@@ -1,0 +1,91 @@
+---
+layout: post
+title:  "April meeting 2019"
+excerpt : "Oskari community day, Oskari dockerization, WFS 3 client, news"
+date:   2019-04-09 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# April meeting 2019
+
+The PSC gathered to discuss the following agenda:
+
+- Last meetings topics
+- News from the members
+- Demo-datasets for demo.oskari.org
+- FOSS4G 2019
+
+## Opening the meeting at 13:04
+
+Via conference call:
+
+- Sami Mäkinen
+- Marko Kuosmanen
+- Jussi Arpalahti´
+- Hafliði Sigtryggur Magnússon
+- Timo Sallinen
+- Tuuli Pihlajamaa
+- Sanna Jokela (secretary)
+
+Not present:
+
+- Tomi Lukkarinen
+- Marko Kauppi
+
+## Last meeting topics and follow-up
+
+Oskari Community Day in Helsinki 25.4. Remember to sign in: https://www.meetup.com/Oskari-Your-geospatial-friend/events/259264054/. 
+
+News: Oskari Dockerization, Map layer admin with React, documentation improved, new download service for Oskari in Tampere
+
+Configuring Oskari setup workshop on 24.4 (in Finnish) https://www.gispo.fi/koulutukset/oskari-haltuun-huhtikuussa/.
+
+GeoNode discussion.
+
+
+## News from the members
+
+Timo:
+- WFS 3.0 support needed for Suomi.fi-maps, test datasets available from NLS-FI
+- Red-hat package are available in Timos GitHub https://github.com/tsallinen/oskari-server-extension-template/tree/rpm-packaging/packages
+
+Marko Kuosmanen: 
+- No news
+
+Jussi: 
+- Breakthrough with Docker image creations, managed to run all ansible-tasks in sample-configs with some changes. No pull request for changes yet, still needs some testing. It went relatively painlessly. Docker image available in: https://github.com/jussiarpalahti/oskariexp & https://hub.docker.com/r/jussiarpalahti/oskari. 
+- Helsinki’s Oskari project has not gone forward. 
+- Jussi interested in the Oskari setup workshop, but can’t participate. 
+
+Haflidi: 
+- Upgrading Oskari (2016 old version) was a bit of a struggle - so many things have changed (and notes from Slack have gone missing!). 
+- Now only some problems with metadata, Islandic localizations have to be corrected. 
+- Discussion about the configuration of layers, do we need to add all layers by hand? Sami: Maybe it could be done automatically 
+- Map projections are a bit confusing in embedded maps (have to look where the problem is). Documentation was not very good on this.
+- Anyhow, things have gone further with Oskari in the past two years!
+
+Tuuli:
+- No news
+
+Sami: 
+- Progress on the new WFS-client with 3.0 support and MVT/GeoJSON output. Still working on stuff like styling for frontend and printing. 
+- New layer admin with React progressed nicely but is currently on hold due to the WFS-client being prioritized. 
+- Metadata search was broken by the Log4J v2 upgrade and a 1.51.1 hotfix is in the works to fix it.
+
+
+## New roadmap issues
+
+- No new issues 
+
+## Other issues
+
+Demo.oskari.org - good quality interface examples? If you want to get featured in the demosite, please inform Sanna or Sami on the ingerfaces. E.g. Thematic maps can not be demonstrated now because there is no data
+- UN statistics API (worldwide data) & Countries Natural Earth for region set could be used with it
+
+FOSS4G 2019 Bukarest, deadline for workshop / presentations in 14th of April (NLS-FI, Gispo people going)
+
+## Next meeting
+
+Next meeting: 14.5.2019, scheduled now every month, every second week tuesday at 13:00 (GMT+3)
+
+## End of meeting: 13:47

--- a/_content/blog/2019-05-14-PSC_May2019.md
+++ b/_content/blog/2019-05-14-PSC_May2019.md
@@ -4,7 +4,7 @@ title:  "May meeting 2019"
 excerpt : "WFS 3 client, UI development, translations to Islandic, migration for WFS platform"
 date:   2019-04-09 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # May meeting 2019

--- a/_content/blog/2019-05-14-PSC_May2019.md
+++ b/_content/blog/2019-05-14-PSC_May2019.md
@@ -4,6 +4,7 @@ title:  "May meeting 2019"
 excerpt : "WFS 3 client, UI development, translations to Islandic, migration for WFS platform"
 date:   2019-04-09 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # May meeting 2019

--- a/_content/blog/2019-05-14-PSC_May2019.md
+++ b/_content/blog/2019-05-14-PSC_May2019.md
@@ -1,0 +1,97 @@
+---
+layout: post
+title:  "May meeting 2019"
+excerpt : "WFS 3 client, UI development, translations to Islandic, migration for WFS platform"
+date:   2019-04-09 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# May meeting 2019
+
+The PSC gathered to discuss the following agenda:
+
+- Last meetings topics
+- News from the members
+- Oskari UI development
+- WFS 3 platform
+
+## Opening the meeting at 13:05
+
+Via conference call:
+
+- Sami Mäkinen
+- Marko Kuosmanen
+- Marko Kauppi
+- Hafliði Sigtryggur Magnússon
+- Timo Sallinen
+
+- Sanna Jokela (secretary)
+
+Not present:
+
+- Tomi Lukkarinen
+- Tuuli Pihlajamaa
+- Jussi Arpalahti´
+
+## Last meeting topics and follow-up
+
+Red-hat packages scripts available if somebody needs them (Timo)
+
+Docker-image experiments (Jussi not present).
+
+Support for WFS 3.0 - still ongoing work, support coming to new tool (Sami).
+
+Oskari Community Day went well - nice to see everybody and we planned ideas for new UI for Oskari (Sanna).
+
+## News from the members
+
+Marko Kuosmanen:
+- SeutuMaisa (following and management of regional landmasses in Helsinki region) development for HSY is ongoing.
+
+Timo: 
+- Suomi.fi-maps: We are currently in process for testing next version of Oskari, WFS 3.0 platform tests.
+
+Sanna:
+- Documentation on Admin-side coming up.
+
+Hafliði: 
+- Transalation to Islandic ready, public version merge possible
+- The problem with metadata discussed last time is no longer valid, there are still some issues with thumbnails coming from Geonetwork which Oskari can not read properly somehow. The issue was asked to be reported.
+- Hafliði was asked to write a blog post about their Oskari setup with Sanna. Sanna will ask some questions and draft the blog post.
+
+Marko Kauppi:
+- City of Tampere has migrated to newest Oskari version
+- Download service coming up
+- Oskari installation workshop was held in April and it went very well, maybe new session in Autumn 2019
+
+Sami: 
+- New release 1.52 coming up in  near future
+- New WFS 3 platform has still some issues and those are tested currently. 1.53 version has the ability to enable new WFS platform, but if you don't want to use it you can skip it. In 1.54 it will be  a forced migration. It provides vectors to browser and enables hovering over features (vector tiles or geojson) and has a new switch in the admin side
+- Thematic map adaptor for UN statistics coming up, it will be used in demo.oskari.org site also
+
+## New roadmap issues
+
+- Migration to the new backend should be described (Sami)
+
+## UI development plan
+
+In Oskari Community day a scheme for developing Oskari UI was drafted https://docs.google.com/document/d/1OnZCWQvEljtWZYm-4gWMkO4OpZviFp_Gx6ZeEMYM5r8/edit. It is still very preliminary and needs work. The idea is to bring Oskari to the 2020s in both appearance and functionalities. These issues have to be taken into account:
+
+- Descriptions for paths to different functionalities
+- How long the old UI will be maintained?
+- Do we have parallel UIs at the same time?
+- Different use cases have to be taken into account
+- We might also have different device needs in the future - how to accomodate those needs?
+- We might have different UIs on top of Oskari (RPC), what do we need to develop in order to enhance these needs
+
+We have to discuss this more at Joint Development Forum and in next PSC meetings and have a session with the developers to come up with a good quality plan. Planning and fund raising is done during 2019, actual development could start in 2020. 
+
+## Other issues
+
+- No other issues
+
+## Next meeting
+
+Next meeting: 11.6.2019, scheduled now every month, every second week tuesday at 13:00 (GMT+3)
+
+## End of meeting: 13:55

--- a/_content/blog/2019-06-11-PSC_June2019.md
+++ b/_content/blog/2019-06-11-PSC_June2019.md
@@ -4,7 +4,7 @@ title:  "June meeting 2019"
 excerpt : ""
 date:   2019-04-09 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # June meeting 2019

--- a/_content/blog/2019-06-11-PSC_June2019.md
+++ b/_content/blog/2019-06-11-PSC_June2019.md
@@ -4,6 +4,7 @@ title:  "June meeting 2019"
 excerpt : ""
 date:   2019-04-09 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # June meeting 2019

--- a/_content/blog/2019-06-11-PSC_June2019.md
+++ b/_content/blog/2019-06-11-PSC_June2019.md
@@ -1,0 +1,108 @@
+---
+layout: post
+title:  "June meeting 2019"
+excerpt : ""
+date:   2019-04-09 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# June meeting 2019
+
+The PSC gathered to discuss the following agenda:
+
+- Last meetings topics
+- News from the members
+- New roadmap items or OIPS
+
+## Opening the meeting at 13:03
+
+Via conference call:
+
+- Sami Mäkinen
+- Marko Kuosmanen
+- Tuuli Pihlajamaa
+- Timo Sallinen
+
+- Sanna Jokela (secretary)
+
+Not present:
+
+- Tomi Lukkarinen
+- Jussi Arpalahti
+- Marko Kauppi
+- Hafliði Sigtryggur Magnússon
+
+## Last meeting topics and follow-up
+
+WFS 3.0 support was released in 1.52 with the new WFS backend that will replace "transport" webapp and is available for testing 
+
+- Suomi.fi-maps has done some tests (Timo)
+- Next step: print support for the new WFS backend
+
+UI-development plan
+
+- Task force gathered to setup project plan for this, they shall continue in August (Sanna)
+
+Translations in Icelandic language
+
+- Sami has received Icelandic translations for server-side localizations and added them to Oskari server
+- Server-side localizations were migrated to using UTF8 encoding
+- Hafliði has promised to provide frontend localizations via a pull request on GitHub
+
+## New release
+
+1.52 version was released recently and 1.53 comming in August-September
+
+## News from the members
+
+Marko Kuosmanen:
+
+- Content-editor changes in the works:
+
+Server-side code is being refactored to use XMLStreamWriter instead of StringBuilder to get rid of some TODOs in the codebase.
+Frontend is being modified to allow multiple features to be edited at once (the properties of features, not geometry).
+PR is coming and Sami reminded that small PRs are easier to check and approve than a big code dump with multiple changes.
+
+- Oliver is also making some tilematrix handling fixes for print functionality (WMTS issues, new guy at Sitowise)
+
+Timo: 
+
+- New WFS support tested in Suomi.fi-maps
+- Taken to production after summer
+
+Sanna:
+
+- Oskari workshop in FOSS4G Bukarest https://docs.google.com/spreadsheets/d/1PmIxRFXxixCb5Szb-hGFG-hcojgk4Nm7sUICZOlmnv4/edit#gid=1318666739
+- Oskari joins OSGeo Park in GIS-EXPO 2019 (Paikkatietomarkkinat)
+- Oskari installation workshop 28.11. with Ubigu & Gispo https://www.oppia.fi/courses/oskari-asennustyopaja-oskari-haltuun/fc0c8e5fc77b700d6b13c5502809982a
+
+Tuuli:
+
+- RPC consulting has been procured and testing period coming up in the fall
+
+Sami: 
+
+- Example webapp has been removed from oskari-server and moved to a "template" repository "sample-server-extension "
+- This guides users on the right track from the start instead of having another example app inside the Oskari codebase.
+- GitHub template functionality was enabled for https://github.com/oskariorg/sample-server-extension and https://github.com/oskariorg/oskari-server-extension-template
+- The old template repository ("oskari-server-extension-template") will be removed with the release of 1.53.0 leaving only one option for server apps to avoid confusion.
+- Map layer rights development is being continued
+- 3D map engine coming to Oskari from Paikkatietoikkuna during summer-fall
+- OSGeo Foundation issues: projects that have been under incubation status have been taken into proper check by OSGeo. OSGeo checklist has been revised and needs to be completed again for Oskari (once we get some more details about it). 
+
+
+## New roadmap issues
+
+- https://github.com/oskariorg/oskari-docs/issues/109 ⇒ approved
+- https://github.com/oskariorg/oskari-docs/issues/112 ⇒ approved
+
+## Other issues
+
+- New PSC member proposals will be made and voted on in the mailing list
+- We still need to work on people moving from private emails and messages to using the mailing list and GitHub: Messaging privately is negative for the community and frustrates both the sender and the recipient.
+
+## Next meeting
+
+Next meeting: 13.8.2019, scheduled now every month, every second week tuesday at 13:00 (GMT+3)
+
+## End of meeting: 13:43

--- a/_content/blog/2019-08-12-PSC_August2019.md
+++ b/_content/blog/2019-08-12-PSC_August2019.md
@@ -4,6 +4,7 @@ title:  "August meeting 2019"
 excerpt : ""
 date:   2019-08-12 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # August meeting 2019

--- a/_content/blog/2019-08-12-PSC_August2019.md
+++ b/_content/blog/2019-08-12-PSC_August2019.md
@@ -4,7 +4,7 @@ title:  "August meeting 2019"
 excerpt : ""
 date:   2019-08-12 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # August meeting 2019

--- a/_content/blog/2019-08-12-PSC_August2019.md
+++ b/_content/blog/2019-08-12-PSC_August2019.md
@@ -1,0 +1,75 @@
+---
+layout: post
+title:  "August meeting 2019"
+excerpt : ""
+date:   2019-08-12 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# August meeting 2019
+
+The PSC gathered to discuss the following agenda:
+
+- News from the members
+
+## Opening the meeting at 13:07
+
+Via conference call:
+
+- Sami Mäkinen
+- Jussi Arpalahti
+- Timo Sallinen
+- Sanna Jokela (secretary)
+
+Not present:
+
+- Tomi Lukkarinen
+- Marko Kuosmanen
+- Tuuli Pihlajamaa
+- Marko Kauppi
+- Hafliði Sigtryggur Magnússon
+
+## Last meeting topics and follow-up
+
+- Content editor changes
+- New WFS support tests
+- Improved documentation
+- Map layer rights development re-starting
+- 3D map motor coming 
+
+
+## News from the members
+
+Timo Sallinen:
+- Suomi.fi-maps has new users: municipalities and Tax Administration in Finland, 
+this is something that could be interesting to other users
+
+Sami:
+- Jetty setup: Java class conflicts from Spring and XML-library dependencies have been resolved
+- Gitter has been active, which is really nice! E.g. University of Lappeenranta was wondering how to include the analysis tool to an application now that they have been moved to oskari-frontend-contrib repository and are no longer part of the sample app.
+- Map layer admin with React and 3D issues hopefully coming up during fall 2019. 
+- 3D in published map is done already for Paikkatietoikkuna and on it's way to be moved to Oskari. Handling "unsupported" map functions are handled using the same workflow as in Arctic SDI with multiple projections. Now we can utilize these features for example when user clicks edit on a 3D published map while in 2D view. 
+
+Jussi:
+- Nothing has happened during summer
+
+Sanna:
+
+- Community page migration under way
+- UI development/”New Oskari” planning in calendar this week with NLS-FI & Sitowise
+- Workshop in FOSS4G Bukarest (on Monday 26th): “Oskari made easy”, planned together with NLS-FI & co
+- Codento Ltd is a new organisational member (now 40 organisations registered in Oskari community)
+
+## New roadmap issues
+
+- No new features
+
+## Other issues
+
+- No other issues
+
+## Next meeting
+
+Next meeting: 10.9.2019, scheduled now every month, every second week tuesday at 13:00 (GMT+3)
+
+## End of meeting: 13:43

--- a/_content/blog/2019-08-12-PSC_September2019.md
+++ b/_content/blog/2019-08-12-PSC_September2019.md
@@ -4,7 +4,7 @@ title:  "September meeting 2019"
 excerpt : "New PSC member, FOSS4G 2019, news from members"
 date:   2019-08-12 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # September meeting 2019

--- a/_content/blog/2019-08-12-PSC_September2019.md
+++ b/_content/blog/2019-08-12-PSC_September2019.md
@@ -4,6 +4,7 @@ title:  "September meeting 2019"
 excerpt : "New PSC member, FOSS4G 2019, news from members"
 date:   2019-08-12 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # September meeting 2019

--- a/_content/blog/2019-08-12-PSC_September2019.md
+++ b/_content/blog/2019-08-12-PSC_September2019.md
@@ -1,0 +1,95 @@
+---
+layout: post
+title:  "September meeting 2019"
+excerpt : "New PSC member, FOSS4G 2019, news from members"
+date:   2019-08-12 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# September meeting 2019
+
+The PSC gathered to discuss the following agenda:
+
+- New PSC member
+- News from the members
+- FOSS4G 2019 conference news
+
+## Opening the meeting at 13:07
+
+Via conference call:
+
+- Sami Mäkinen
+- Jussi Arpalahti
+- Timo Sallinen
+- Tuuli Pihlajamaa
+- Hafliði Sigtryggur Magnússon
+- Marko Kuosmanen
+- Sanna Jokela (secretary)
+
+Not present:
+
+- Tomi Lukkarinen
+- Marko Kauppi
+
+## Last meeting topics and follow-up
+
+- Suomi.fi-maps spreads toward municipalities in Finland
+- FOSS4G workshop preparations
+- Community page migration on the way
+
+## New PSC member
+
+- Oskari Rintamäki was elected to be the new PSC member
+
+## FOSS4G 2019 Conference news
+
+- Oskari was presented in a [workshop](https://github.com/oskariorg/oskari-docs/blob/master/md/documentation/examples/FOSS4G_2019/workshop.md), very clear instructions to set up published map and tailor it with RPC. Wishlist from the audience: installation workshop for Oskari
+- Timo Aarnio and Sami had their presentations
+- Oskari was presented in the [OSGeo AGM](https://docs.google.com/presentation/d/1imiG7x09ry7lGvmS15FCVq2Z7yaICY00fcpXBK27TXY/edit) by Sanna (one slide, very quick appearance)
+
+## News from the members
+
+Sami:
+- We have moved forward with the permission handling oip implementation (https://github.com/oskariorg/oskari-docs/issues/72)
+- Release plans posted last week (1.53 coming in a few weeks ~20.9., 1.54 at the end of October). 
+- Feedback needed! 
+- On 1.53 we will have an automatic migration to the new system but you can still opt-out of it. 
+- On 1.54 we will "force" everyone to switch from transport to the new system and there's probably something that still doesn't work (like the content-editor maybe?)
+- For 1.53 features include things like: the new WFS-system (improved from 1.52 where it was already possible to try it)
+sample app has been MOVED and improved from oskari-server to sample-server-extension repository (that is replacing the current oskari-server-extension-template repository) ⇒ this is how we see Oskari based apps should be created from now on
+- For 1.54 features we are targeting to have: the 3D-mapmodule that we've developed on demo-kartta.paikkatietoikkuna.fi to be included in official Oskari codebase
+rewrite for the map layer listing/admin tools based on React (layer list similar as the hierarchical layer listing, but admin side is changed more)
+
+Marko Kuosmanen: 
+- New use case / feature coming: In mobile users can track location (first zoom & set current location map), show point when you moving. Maybe need to be configurable in MyLocationPlugin? Also how user can stop tracking, maybe clicking icon (in this way icon toggle tracking / not tracking)? Maybe this needs also desktop mode configuration? Marko adds this to github (https://github.com/oskariorg/oskari-docs/issues/126), some questions still
+- Traficom: new Oskari setup coming soon
+
+Tuuli: 
+- Version update in Statistics Finland’s Oskari Beta Service is planned to be in October. https://tilastokeskusoskari.sitowise.com/
+
+Sanna:
+- Oskari [tour](https://www.meetup.com/Oskari-Your-geospatial-friend/) coming to Finland, test for workshop material with RPC: https://codepen.io/sannajokela/project/full/ZLxOpQ
+
+Jussi: 
+- Nothing from Helsinki
+
+Haflidi:
+- Focusing on installation of new version. Gave up migrating old layers from database. Now going well, no problems at the moment, old bugs are gone, which is good. Bing maps now in use, styling is odd.
+- Question: How to add OSM if you are not using default setup? Sami: sample from demo.oskari is from Maptiler, but they might have some limitations for use
+- Some translations and then release: https://ggn01.lmi.is/ (sign in needed)
+
+
+## New roadmap issues
+
+- No new features
+
+## Other issues
+
+- Mapstore vs. Oskari, very similar features - cooperation maybe possible, javascript modules and react, needs GeoServer to function (end user interface for GeoServer)
+
+
+## Next meeting
+
+Next meeting: 10.9.2019, scheduled now every month, every second week tuesday at 13:00 (GMT+3)
+
+## End of meeting: 13:41

--- a/_content/blog/2019-09-18-3D_coming_up.md
+++ b/_content/blog/2019-09-18-3D_coming_up.md
@@ -1,0 +1,27 @@
+---
+layout: post
+title:  "3D project is moving one dimension at a time"
+excerpt : "3D possibilities for Oskari are being developed in the National Land Survey of Finland"
+date:   2019-09-19 13:00:00 +0300
+categories: [news]
+---
+
+# 3D and Oskari
+
+3D possibilities for Oskari are being developed in the National Land Survey of Finland. The need to show e.g. building data in 3D has been a growing trend but now also the national topographic database is to support 3D objects. The project started 2018 and the aim is to develop 3D support as part of Oskari. This enables usage of 3D features in any map applications based on the software.
+
+Hanna Visuri, application specialist from NLS-FI tells us more about the project:
+
+"The National Land Survey of Finland is producing a uniform 3D dataset from the whole country and has started a project to enable the visualization of the 3D data in administrative map applications."
+
+Production level support for 3D will be included in a December 2019 release, but an example of the Oskari-based 3D map can already be seen in the [National Geoportal development environment](https://demo-kartta.paikkatietoikkuna.fi).
+
+## Cesium and 3D Tiles
+
+"Oskari uses CesiumJS for 3D map rendering and 3D Tiles for streaming and rendering 3D geospatial data including buildings, point clouds and digital elevation models," Visuri explains.
+
+"Oskari enables reviewing the imported 3D data against any map layer available via standard interfaces such as Web Feature Service and Web Map Service. It will also enable displaying property information of buildings, rule-based rendering and as the most important feature: offering embedded maps containing 3D spatial data," she continues.
+
+The 3D project has started already in 2018 and the aim is to pilot the 3D possibilities in Oskari, re-fracture the code to more general format and create admin side tools for 3D data. At the moment it is already possible to test the new features with certain 3D datasets from WFS interfaces from cities of Helsinki and Tampere.
+
+How would you use 3D data in Oskari and what are the needs from the Oskari Community? Let us know!

--- a/_content/blog/2019-09-18-3D_coming_up.md
+++ b/_content/blog/2019-09-18-3D_coming_up.md
@@ -4,7 +4,7 @@ title:  "3D project is moving one dimension at a time"
 excerpt : "3D possibilities for Oskari are being developed in the National Land Survey of Finland"
 date:   2019-09-19 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # 3D and Oskari

--- a/_content/blog/2019-09-18-3D_coming_up.md
+++ b/_content/blog/2019-09-18-3D_coming_up.md
@@ -4,6 +4,7 @@ title:  "3D project is moving one dimension at a time"
 excerpt : "3D possibilities for Oskari are being developed in the National Land Survey of Finland"
 date:   2019-09-19 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # 3D and Oskari

--- a/_content/blog/2019-10-25-OSGeo_Oskari_tour.md
+++ b/_content/blog/2019-10-25-OSGeo_Oskari_tour.md
@@ -4,6 +4,7 @@ title:  "Oskari & OSGeo on tour 2019"
 excerpt : "Oskari went on tour with OSGeo Finland to meet some open minded people around Finland"
 date:   2019-10-25 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Oskari & OSGeo were on tour

--- a/_content/blog/2019-10-25-OSGeo_Oskari_tour.md
+++ b/_content/blog/2019-10-25-OSGeo_Oskari_tour.md
@@ -4,7 +4,7 @@ title:  "Oskari & OSGeo on tour 2019"
 excerpt : "Oskari went on tour with OSGeo Finland to meet some open minded people around Finland"
 date:   2019-10-25 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Oskari & OSGeo were on tour

--- a/_content/blog/2019-10-25-OSGeo_Oskari_tour.md
+++ b/_content/blog/2019-10-25-OSGeo_Oskari_tour.md
@@ -1,0 +1,57 @@
+---
+layout: post
+title:  "Oskari & OSGeo on tour 2019"
+excerpt : "Oskari went on tour with OSGeo Finland to meet some open minded people around Finland"
+date:   2019-10-25 13:00:00 +0300
+categories: [news]
+---
+
+# Oskari & OSGeo were on tour
+
+It was a brilliant open source tour through the whole of Finland in October!
+
+This was the fist time we arranged a tour with [OSGeo Finland association](http://www.osgeo.fi/) and Oskari Community 
+and met open source people of cities of Turku, Tampere and Joensuu. 
+The aim was to learn new things with FOSS4G tools and get familiar with Oskari RPC.
+
+We used the workshop material provided for [FOSS4G 2019 Bucharest conference](https://github.com/oskariorg/oskari-docs/tree/master/md/documentation/examples/FOSS4G_2019). 
+With those instruction we were able to get to the bottom of the realms of Oskari's embedded maps and API. 
+Thanks for the instructions, NLS-FI Oskari developer team!
+
+The event was in Finnish and presentations can be found [here](https://drive.google.com/drive/u/0/folders/1bFShE-Pon6NexBL4ZhAkHxTF0iFM0Hb9). 
+Thanks again for all the participants and organizers!
+
+<img src="/img/mapquery_oskari.png" width="500" class="img-responsive"/>
+
+Public participation is part of the land use planning process. In Tampere they have all the datasets in their Oskari installation, so it was convenient to create a simple query form on top of Oskari embedded map.
+
+<img src="/img/joensuu_gfi_example.png" width="500" class="img-responsive"/>
+
+City of Joensuu has taken Oskari in use during this year and they have created nice looking info-popups with GeoServer GFI and Google Charts API.
+
+<img src="/img/private_road.png" width="500" class="img-responsive"/>
+
+Private road management information can be informed with a form using Oskari embedded map.
+
+## Here are some of the best ways we found out Oskari was used during the tour
+
+- [Private road information form](https://julkinen.vayla.fi/yksityistie/) has been created using Oskari embedded map and RPC, provided for Väylä by Sitowise Ltd
+- [SeutuAtlas](http://www.seutuatlas.fi/index.jsp), a tool for checking the solar potential of buildings in Helsinki, provided for HSY by Sitowise Ltd
+- City of Tampere, [Oskari installation with role based layer control](https://kartat.tampere.fi/oskari/) provides around 600 map layers internally and around 200 layers for public use
+- [Public participation query tool](https://kartat.tampere.fi/palautedemo/) with Oskari was created for use of general land use planning in Tampere, provided by Erno Mäkinen, City of Tampere
+- City of Joensuu, [Oskari installation with GFI integration with Google Charts API](https://oskari.joensuu.fi/?zoomLevel=8&coord=646669.632895638_6942732.815604098&mapLayers=52+100+raster,115+100+Muutos:%202014%20-%20nykyhetki,120+100+V%C3%A4est%C3%B6n%20lukum%C3%A4%C3%A4r%C3%A4&uuid=8c4d8671-cd00-41eb-992a-0aa6f21c463c&noSavedState=true&showIntro=false)
+
+## Other interesting FOSS4G cases:
+
+- [Potree for point clouds](http://potree.org/), needs web-service environment for setting up, installation used in City of Turku by Niko-Petteri Salo
+- [Service point map](https://palvelukartta.turku.fi/), installation for City of Turku, developed originally by City of Helsinki
+- [Cesium-based 3D map service in Tampere](https://kartat.tampere.fi/cesium_web#) is assembling the growing amount of drone data gathered in City of Tampere
+- [QGIS and PostGIS setup for CO2 calculation](https://github.com/GispoCoding/assessclimateimpact)  provides possibilities to predict future emissions, by Ubigu Ltd, Tietotakomo and Gispo Ltd
+- [SPARQL](https://en.wikipedia.org/wiki/SPARQL) provides possibility to link statistical and geospatial data
+- [ProMS-platform by Arbonaut Ltd](https://www.arbonaut.com/en/products/proms) provides e.g. a possibility to calculate tree polygons from aerial imagery and analyze if they cross electricity lines. ProMS uses different FOSS4G tools in the background.
+- [R](https://www.r-project.org/) tool for statistical and geospatial analysis revealed that the countryside in Finland is not totally empty, just during the last statistical day of the year.
+
+
+
+
+

--- a/_content/blog/2019-11-11-PSC_November2019.md
+++ b/_content/blog/2019-11-11-PSC_November2019.md
@@ -4,6 +4,7 @@ title:  "November meeting 2019"
 excerpt : ""
 date:   2019-11-11 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # November meeting 2019

--- a/_content/blog/2019-11-11-PSC_November2019.md
+++ b/_content/blog/2019-11-11-PSC_November2019.md
@@ -1,0 +1,76 @@
+---
+layout: post
+title:  "November meeting 2019"
+excerpt : ""
+date:   2019-11-11 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# November meeting 2019
+
+The PSC gathered to discuss the following agenda:
+
+- 3D & Oskari
+- Layer list enhancement
+- WFS backend tests
+
+## Opening the meeting at 13:04
+
+Via conference call:
+
+- Sami Mäkinen
+- Oskari Rintamäki
+- Timo Sallinen
+- Tuuli Pihlajamaa
+
+- Sanna Jokela (secretary)
+
+Not present:
+
+- Tomi Lukkarinen
+- Jussi Arpalahti
+- Marko Kauppi
+- Hafliði Sigtryggur Magnússon
+- Marko Kuosmanen
+
+## Last meeting topics and follow-up
+
+- Oskari Rintamäki a new PSC member
+- FOSS4G 2019 news and news from the members
+- 1.53 coming up (now released), 1.54 coming soon:
+- new layer list coming, release maybe next week, check the new layer list functionality from: https://demo-kartta.paikkatietoikkuna.fi/. It started from Admin side improvements, but it was decided to go ahead first with combining the layer list and selected layers. If somebody wants to add hierarchy to the layers, they could develop this further. Also if old hierarchical layer functionality needs the admin side functions, they could attach the new admin tools to the existing layer listing. 
+Mobile tracking improvement coming up, now new possibilities for showing location of users in published maps
+- Deprecated transport code still available, but not tested
+- New WFS backend, strong recommendation to use the new one
+
+## 3D needs
+
+3D needs was discussed and no acute needs for 3D showed up by the members of PSC. 3D needs should be further discussed with Oskari users.
+
+Cesium provides the 3D possiblities in Oskari and thus it can do things supported in Cesium. 
+
+Own 3D datasets could be a possibility to add to the tool. 
+
+3D module is coming to the next release. 
+
+## WFS backend tests
+
+- Some bug reports from customers about My data, but this has to be checked
+- Interface with arc/surface, data with multigeometry had some issues
+- Testing still needed
+
+## Other issues
+
+- GIS Expo in Finland 18.-19.11.2019, see you at the Oskari stand
+- UI development scheme coming up
+- Mobile version for Paikkatietoikkuna under development, own geoportal view for mobile use
+
+## New roadmap issues
+
+- No new features
+
+## Next meeting
+
+Next meeting: 10.12.2019, scheduled now every month, every second week tuesday at 13:00 (GMT+3)
+
+## End of meeting: 13:45

--- a/_content/blog/2019-11-11-PSC_November2019.md
+++ b/_content/blog/2019-11-11-PSC_November2019.md
@@ -4,7 +4,7 @@ title:  "November meeting 2019"
 excerpt : ""
 date:   2019-11-11 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # November meeting 2019

--- a/_content/blog/2019-11-20-3D_to_core.md
+++ b/_content/blog/2019-11-20-3D_to_core.md
@@ -4,7 +4,7 @@ title:  "3D Tiles, here they come"
 excerpt : "Oskari has the ability to handle 3D datasets."
 date:   2019-11-20 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Oskari and 3D

--- a/_content/blog/2019-11-20-3D_to_core.md
+++ b/_content/blog/2019-11-20-3D_to_core.md
@@ -1,0 +1,31 @@
+---
+layout: post
+title:  "3D Tiles, here they come"
+excerpt : "Oskari has the ability to handle 3D datasets."
+date:   2019-11-20 13:00:00 +0300
+categories: [news]
+---
+
+# Oskari and 3D
+
+As from Oskari version 1.54 Oskari has had the ability to handle 3D datasets. Oskari supports 3D Tiles which is a OGC Community Standard. 
+Documentation for Oskari 3D can be found [here](www.oskari.org/documentation/features/3D).
+
+<img src="/img/3D_nlsfi.png" width="500" class="img-responsive"/>
+
+Check out 3D possibilities in e.g. [Paikkatietoikkuna](https://kartta.paikkatietoikkuna.fi/?lang=en). Choose 3D view and add datasets – you can find them by e.g. typing “3D” to the search.
+
+You can add also textures to buildings. Terrain data can be measured with terrain profile. You can also add you own POIs on top of the 3D model.
+
+## CityGML into Cesium
+
+Hanna Visuri demonstrated the use of 3D tiles in Oskari in a [webinar](http://kmtk.paikkatietoalusta.fi/ajankohtaista/oskari-goes-3d-uutta-3d-nakymaa-esiteltiin-webinaarissa-312) in Finnish (3.12.2019).
+
+The datasets used in the demo have been created using FME to convert CityGML into Cesium 3D tiles. Available datasets are from cities of Tampere and Helsinki. Tiling has been done by NLS-FI.
+
+Oskari RPC can be used to create camera views over the data. The request handles camera points and angles at the moment.
+
+## Future plans
+More to come soon: adjusting time of the day (shadows), camera controls and admin-side support for Cesium Ion hosted datasets.
+
+Next steps: drawing of 3D features, bring feature information as a table and style information based on attribute table.

--- a/_content/blog/2019-11-20-3D_to_core.md
+++ b/_content/blog/2019-11-20-3D_to_core.md
@@ -4,6 +4,7 @@ title:  "3D Tiles, here they come"
 excerpt : "Oskari has the ability to handle 3D datasets."
 date:   2019-11-20 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Oskari and 3D

--- a/_content/blog/2019-12-10-PSC_December2019.md
+++ b/_content/blog/2019-12-10-PSC_December2019.md
@@ -4,6 +4,7 @@ title:  "December meeting 2019"
 excerpt : ""
 date:   2019-12-10 13:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # December meeting 2019

--- a/_content/blog/2019-12-10-PSC_December2019.md
+++ b/_content/blog/2019-12-10-PSC_December2019.md
@@ -1,0 +1,82 @@
+---
+layout: post
+title:  "December meeting 2019"
+excerpt : ""
+date:   2019-12-10 13:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# December meeting 2019
+
+The PSC gathered to discuss the following agenda:
+
+- PSC meetings and members
+- New issues
+- Oskari UI
+- Other issues
+
+## Opening the meeting at 13:03
+
+Via conference call:
+
+- Sami Mäkinen
+- Oskari Rintamäki
+- Timo Sallinen
+- Jussi Arpalahti
+- Marko Kuosmanen
+
+- Sanna Jokela (secretary)
+
+Not present:
+
+- Tomi Lukkarinen
+- Tuuli Pihlajamaa
+- Marko Kauppi
+- Hafliði Sigtryggur Magnússon
+
+
+## Last meeting topics and follow-up
+
+- Discussion about 3D needs, if you have any ideas for it, please add issues to GitHub
+- WFS backend tests: Fixed issue, GeoServer no longer crashes (ticket to GeoSolution). Last release (1.54) ⇒ force of new WFS backend
+
+
+## PSC meetings
+
+- It was discussed and decided that PSC meetings will be held in Gitter and issues are to be discussed and decided when needed. Skype-meetings can be arranged by Sami when needed. Pros for this is that other Gitter followers can easily see what has been decided. 
+- Sanna will no longer act as a secretary, only if needed
+
+## PSC members
+
+- Tomi Lukkarinen wants to step down from the PSC
+- Marko Kauppi has not been active, PSC reserved the right to remove him from the PSC. 
+- PSC thanks Tomi and Marko for their participation and welcomes them back in any time!
+
+## Release notes - reminder
+
+- Release notes can be seen from milestones in GitHub - features that should be in the next release should be discussed within PSC. Now the release schedule is decided mainly inside NLS-Finland
+
+## OIPS, issues, ideas
+
+- Map Layers search filter for other things than name, producer, theme  ⇒ Rintamäki will create an issue to GitHub
+- Excel export should export feature attributes into multiple sheets in some cases. Also the export should have an option to export all the features in the layer instead of features visible in the map view  ⇒ Kuosmanen / Rintamäki will create an issue
+- Content editor fix with new WFS: now hides other layers  ⇒ bug fix coming up. It was also discussed if there is geometry checking in Oskari front, because there are some problems when drawing multiple features. Answer: Some topology checks are available, but not for overlapping features.
+- New layer listing is being developed and coming up also to the admin side (NLS-FI). Question/take in to consideration: could this be taken into account also in the hierarchical layer list bundle?
+
+## UI development
+
+- Paikkatietoikkuna is being checked by a service designer  ⇒ mockups about new UI
+- Joint Development Forum will propably hire more service design for Oskari core UI development
+- These plans should be discussed inside the PSC
+
+## Other issues
+
+- 1.53 refractored rights for Oskari server, non-admin users may see information about layers that should only be visible for admins. This will be hotfixed shortly as 1.54.1. Sami will send workaround to Marko Kuosmanen.
+- 1.54.0 frontend had some problems related to OpenLayers upgrade ⇒ hotfix coming up for these as well
+
+
+## Next meeting
+
+Next meeting: when needed, Sanna will remove calendar meetings.
+
+## End of meeting: 13:45

--- a/_content/blog/2019-12-10-PSC_December2019.md
+++ b/_content/blog/2019-12-10-PSC_December2019.md
@@ -4,7 +4,7 @@ title:  "December meeting 2019"
 excerpt : ""
 date:   2019-12-10 13:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # December meeting 2019

--- a/_content/blog/2020-05-26-Oskari_embedded_maps.md
+++ b/_content/blog/2020-05-26-Oskari_embedded_maps.md
@@ -4,7 +4,7 @@ title:  "Testing Oskari embedded maps"
 excerpt : "How easy it is to create your own embedded map to your web site? So easy!"
 date:   2020-05-26 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # How easy it is to create your own Oskari based map?

--- a/_content/blog/2020-05-26-Oskari_embedded_maps.md
+++ b/_content/blog/2020-05-26-Oskari_embedded_maps.md
@@ -1,0 +1,65 @@
+---
+layout: post
+title:  "Testing Oskari embedded maps"
+excerpt : "How easy it is to create your own embedded map to your web site? So easy!"
+date:   2020-05-26 13:00:00 +0300
+categories: [news]
+---
+
+# How easy it is to create your own Oskari based map?
+
+In this blog post Jan Lindbom, the CPO/CTO in Sitowise Ltd explains to how to create a light weight map service with Oskari. We shall try to do what he instructs.
+
+## 1.  Access to Oskari
+
+_“You have to have an access to a Oskari platform that offers the possibility to publish maps,”_ he starts. 
+
+So go to a service like [Paikkatietoikkuna](https://kartta.paikkatietoikkuna.fi/?lang=en), [Suomi.fi-maps](https://www.maanmittauslaitos.fi/asioi-verkossa/suomifi-kartat) or similar. 
+
+You can also try this with [Oskari demo](https://demo.oskari.org/), but remember it will erase all saved information every day.
+
+## 2. Sign in and add data or map layers
+
+_“You need to publish a map with Oskari's ready to use functionality with an easy to use web interface.”_
+
+This can be done with signing in as a user, choosing a background maps or other available map layers. In this example we are using the Finnish national geoportal called Paikkatietoikkuna and some data fetched from [OpenStreetMap](https://www.openstreetmap.org/).
+
+- **Sign in** to your Oskari instance
+- Add existing map layers to your map if needed
+- Add own datasets if you want and select a suitable style for your points, lines or polygons. 
+
+The styling abilities are a bit limited. But you can adjust the style also afterwards from **My data**-section. Notice, that adding own data is possible only if it is allowed in the used Oskari instance. The abilities of Oskari can vary according to the service provider. But adding own data and publishing maps is a core element of Oskari. 
+
+We used QGIS and QuickOSM tool to fetch coffeeshops from the city centre of Turku. At the moment Oskari allows datasets to be imported in zip-format and it supports ESRI .shp, .GPX, Mapinfo .mif and Google .KML-formats. 
+
+<img src="/img/owndatasets.png" width="500" class="img-responsive"/>
+
+<img src="/img/edit_owndata.png" width="500" class="img-responsive"/>
+
+## 3. Publish the map
+
+- Click on **Map Publishing** and give the map a name and the URL where you want to post it
+
+<img src="/img/publishing.png" width="500" class="img-responsive"/>
+
+<img src="/img/embedded_maps_create.png" width="500" class="img-responsive"/>
+
+- Adjust the needed elements and tools to the map
+- Click publish and copy paste the iframe code to your website. 
+
+<iframe src="https://kartta.paikkatietoikkuna.fi/published/en/4fc5a1ea-6374-4ecb-a40f-3aa2f665732d" allow="geolocation" style="border: none; width: 500px; height: 500px;"></iframe>
+ 
+## 4. If you want to tailor the embedded map to your own needs, learn RPC
+
+Oskari's published maps can be tailored to make them look exactly as you like. This is done by using Oskari RPC (Remote Procedure Call).
+
+_“And the last and most important part, you need to have application developer knowledge to be able to develop the integration to the other system by RPC. You need to know the system to which you are integrating at the technical level also.”_
+
+_“The advantage of using RPC is that the map interface can be easily integrated into a part of another system and make it work interactively”,_ Jan explains.
+
+- [Examples of Oskari RPC](https://oskari.org/examples/rpc-api/rpc_example.html) to tailor the embedded maps
+- [Guide](https://oskari.org/guides/rpc-step-by-step)
+- Check the gallery of some examples, like [Fishing restrictions](https://www.oskari.org/gallery/fishing_restrictions) and [Social insurance service search](https://www.oskari.org/gallery/kela)
+- [Test the workshop material created for FOSS4G 2019](https://www.oskari.org/documentation/examples/FOSS4G_2019/workshop)
+
+_Reviewed and rewritten in 2020-05-26, original story written in 2019-01-07._

--- a/_content/blog/2020-05-26-Oskari_embedded_maps.md
+++ b/_content/blog/2020-05-26-Oskari_embedded_maps.md
@@ -4,6 +4,7 @@ title:  "Testing Oskari embedded maps"
 excerpt : "How easy it is to create your own embedded map to your web site? So easy!"
 date:   2020-05-26 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # How easy it is to create your own Oskari based map?

--- a/_content/blog/2020-06-10-Oskari_3D_videos.md
+++ b/_content/blog/2020-06-10-Oskari_3D_videos.md
@@ -4,7 +4,7 @@ title:  "3D capabilities of Oskari with videos"
 excerpt : "3D view and terrain height profile tool"
 date:   2020-06-10 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Testing Oskari 3D-possibilities 

--- a/_content/blog/2020-06-10-Oskari_3D_videos.md
+++ b/_content/blog/2020-06-10-Oskari_3D_videos.md
@@ -4,6 +4,7 @@ title:  "3D capabilities of Oskari with videos"
 excerpt : "3D view and terrain height profile tool"
 date:   2020-06-10 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Testing Oskari 3D-possibilities 

--- a/_content/blog/2020-06-10-Oskari_3D_videos.md
+++ b/_content/blog/2020-06-10-Oskari_3D_videos.md
@@ -1,0 +1,56 @@
+---
+layout: post
+title:  "3D capabilities of Oskari with videos"
+excerpt : "3D view and terrain height profile tool"
+date:   2020-06-10 13:00:00 +0300
+categories: [news]
+---
+
+# Testing Oskari 3D-possibilities 
+
+Oskari Joint Development Forum has created a video how to use 3D datasets.
+
+## Spin the world with the Oskari demo website
+
+If you have not tried yet, test Oskari 3D possibilities with the demo website. 
+
+[See the whole video about 3D in demo Oskari.](https://youtu.be/ISKkL1_-svc)
+
+1. First test the "Blue Marble" as background map and switch to 3D view [go to demo Oskari from here](https://demo.oskari.org/)
+2. You can spin the globe with shift pressed down
+
+<img src="/img/demo_bluemarble.png" class="img-responsive"/>
+
+3. There are 2 datasets currently available with 3D data in the demo website, so let's check them out. Zoom to Helsinki (Finland). 
+4. If the background map gets blurry, change the background map to e.g. "NLS-FI Background map"
+5. Test the mesh dataset (Helsinki city 3D) from Helsinki and the city GML model (Helsinki city 3D buildings with textures). See how the buildings float on top of the map.
+
+<img src="/img/helsinki_3D.png" class="img-responsive"/>
+
+
+# Testing the Terrain Height Profile tool with Paikkatietoikkuna
+
+The Finnish National Land Survey has tested the possibilities of WCS (Web Coverage Service) and created an addition to their Oskari installation called Terrain Height Profile.
+It is not a core element for Oskari, but there is some documentation available [here](https://github.com/nls-oskari/kartta.paikkatietoikkuna.fi/tree/develop/service-terrain-profile). 
+If you want to have similar, it depends on the data available. This is just one example on how WCS could be used. 
+
+In Paikkatietoikkuna there is also a digital elevation model available (data comes from Cesium), so we can test how the 3D buildings go on top of the terrain model nicely.
+
+[See the video about using Terrain profile tool](https://youtu.be/CO9tqsSHe60)
+
+
+1. Open [Paikkatietoikkuna](https://kartta.paikkatietoikkuna.fi/) and switch to 3D view and zoom to Helsinki
+2. Add e.g. orthophotograph and 3D model to the map view. 
+You can see that the buildings are not floating on top of the terrain, due to digital elevation model provided by Cesium in the background.
+3. Choose a place where you want to measure the terrain.
+4. Click the terrain profile tool and start measuring.  The tool switches to 2D mode, so the measuring is more easy to do. 
+End the measurement with double click. You get a profile for the terrain in a graph.
+5. You can check the actual height of the terrain with following the graphs profile.
+
+<img src="/img/3D_paikkatietoikkuna.png" class="img-responsive"/>
+
+<img src="/img/terrainheightprofile.png" class="img-responsive"/>
+
+An example of the [WCS Get Capabilities query used in here](https://beta-karttakuva.maanmittauslaitos.fi/wcs/service/ows?service=WCS&AcceptVersions=2.0.1&request=GetCapabilities).
+
+

--- a/_content/blog/2020-06-12-Oskari_admin.md
+++ b/_content/blog/2020-06-12-Oskari_admin.md
@@ -1,0 +1,108 @@
+---
+layout: post
+title:  "Admin tools in Oskari"
+excerpt : "Guide to use Oskari admin tools"
+date:   2020-06-12 13:00:00 +0300
+categories: [news]
+---
+
+# Oskari admin tools have renewed so here is a tutorial for adminstrators
+
+In the [video](https://youtu.be/xeOM0_1zO2I) there is a tutorial and tests for the relatively new admin side tool in Oskari. 
+
+You can test admin-side tools with Oskari [demo site](https://demo.oskari.org/) which is an Oskari set-up that everyone can try out without their own Oskari installation. 
+Access the admin tool by logging in and use the test passwords, found actually from the start help. 
+Remember that all information is deleted from the demo site during the night, so don’t store any crucial datasets there.
+
+Prerequisities for administrators: you have to have some knowledge on OGC standards like [WMS](https://www.ogc.org/standards/wms) and [WFS](https://www.ogc.org/standards/wfs). 
+
+## Supported map layer types
+
+<img src="/img/layer_admin.png" class="img-responsive"/>
+
+Oskari supports different standard interfaces like Web Map Service, Web Map Tile Service, Web Feature Service. 
+And you can also add layers from Bing or services providing Mapbox vector tiles or Cesium 3D-tiles. 
+If these are not familiar to you, we suggest you read on how to create WMS-services with GeoServer or similar map server. 
+In short, there are different ways to provide interfaces for your data.
+
+## 1. Adding data providers and themes
+
+Oskari is originally created for geoportal purposes, so all the datasets should have a data provider and also some kind of category or theme. 
+
+When you are logged in you can add data providers, themes and data thourgh map layers window by clicking the + button.
+
+<img src="/img/admin_button_maplayers.png" class="img-responsive"/>
+
+
+## 2. Adding a basic information from a WMS/WFS layer
+
+Test data used in the video:
+
+- [WMS from SEDAC](https://sedac.ciesin.columbia.edu/geoserver/wms)
+- [WFS from Väylävirasto](https://julkinen.vayla.fi/inspirepalvelu/avoin/wfs?request=getcapabilities)
+
+<img src="/img/layer_admin2.png" class="img-responsive"/>
+
+1. Add an URL link for your WMS/WFS and passwords if needed
+2. Select the correct version for the WMS/WFS
+3. Browse through or find the wanted map layer with search (usually there are lot of layers to choose from in a single service)
+4. Set the SRS (coordinate system) or leave it as it is.
+5. The name of the dataset should come straight from the GetCapabilities query but you can also change the default names
+6. You can also add different translations for your dataset if your Oskari installation supports several languages
+7. Select the data provider and theme/group
+8. Finally, do not finish yet but go up the form and proceed in to the next sheet
+
+## 3. Visualisation possibilities
+
+For WMS data the only option is to select default value for transparency (the user can adjust this at runtime).
+
+For WFS data you can have more options:
+
+- Try data clustering for points, by adding some point distance for points you want to cluster.
+- Select if data with lots of small items should be optimized for browser (MVT) or just use GeoJSON as the default safe option
+- Style definitions with JSON: own styling for WFS-datasets
+- Feature highlighting and tooltip with JSON: own styling
+
+<img src="/img/visualization_WFS.png" class="img-responsive"/>
+
+## 4. Additional information
+
+In the next sheet, you can assign some additional information. For WMS and WFS there are slightly different options.
+
+- Update rate for capabilities (in seconds), this is for e.g. datasets that need to be refreshed often like timeseries information
+- Metadata link, in some cases it is already attached to the WMS/WFS GetCapabilities request
+- For WMS layers you can add an other legend URL, if you don't want to use the dataproviders own legend
+- Real time layer for datasets that have data that is updated on the map frequently (like moving busses or weather data)
+
+<img src="/img/additional_information.png" class="img-responsive"/>
+
+## 5. User rights
+
+You can assign role-based access rights for your map layer for adminstrators, guests and signed in users. 
+- **View:** layer visibility can be restricted to a certain user group. 
+- **View in embedded map:** this option refers to the embedded map and tells if the data can be only viewed within the embedded map. 
+- **Publish:** you can also add restrictions for using the layer in question in published maps
+- **Download:** this possibility is actually used only for WFS data, it allows downloading the attribute data in CSV or Excel format.
+
+<img src="/img/user_rights.png" class="img-responsive"/>
+
+## 6. Finally: Add the layer to your map
+
+And check if everything is ok. You can always edit the layer information from Map Layers if the pen-tool is active and you are logged in. 
+
+## 7. Extra: Adding 3D dataset from Cesium
+
+In the video we tested also how to add 3D data from Cesium to the map. 
+You need to sign in to [Cesium](https://cesium.com/) and find e.g. OpenStreetMap Buildings asset id and you need a token.
+
+<img src="/img/cesium.png" class="img-responsive"/>
+
+1. Add a new layer and choose Cesium
+2. Add the Asset ID
+3. Add Access Token
+4. Add necessary information, like layer name, data provider, theme
+5. Test in 3D view to see the dataset in action
+
+
+
+

--- a/_content/blog/2020-06-12-Oskari_admin.md
+++ b/_content/blog/2020-06-12-Oskari_admin.md
@@ -4,7 +4,7 @@ title:  "Admin tools in Oskari"
 excerpt : "Guide to use Oskari admin tools"
 date:   2020-06-12 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Oskari admin tools have renewed so here is a tutorial for adminstrators

--- a/_content/blog/2020-06-12-Oskari_admin.md
+++ b/_content/blog/2020-06-12-Oskari_admin.md
@@ -4,6 +4,7 @@ title:  "Admin tools in Oskari"
 excerpt : "Guide to use Oskari admin tools"
 date:   2020-06-12 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Oskari admin tools have renewed so here is a tutorial for adminstrators

--- a/_content/blog/2020-06-17-StatisticsFinland.md
+++ b/_content/blog/2020-06-17-StatisticsFinland.md
@@ -4,6 +4,7 @@ title:  "Statistics Finland has a brand new Oskari"
 excerpt : "Time series and thematic maps from Finland"
 date:   2020-06-17 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Statistics Finland has a brand new Oskari

--- a/_content/blog/2020-06-17-StatisticsFinland.md
+++ b/_content/blog/2020-06-17-StatisticsFinland.md
@@ -4,7 +4,7 @@ title:  "Statistics Finland has a brand new Oskari"
 excerpt : "Time series and thematic maps from Finland"
 date:   2020-06-17 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Statistics Finland has a brand new Oskari

--- a/_content/blog/2020-06-17-StatisticsFinland.md
+++ b/_content/blog/2020-06-17-StatisticsFinland.md
@@ -1,0 +1,45 @@
+---
+layout: post
+title:  "Statistics Finland has a brand new Oskari"
+excerpt : "Time series and thematic maps from Finland"
+date:   2020-06-17 13:00:00 +0300
+categories: [news]
+---
+
+# Statistics Finland has a brand new Oskari
+
+All of Statistics Finland's open geospatial data sets are available in Statistics Finland's new [map service](https://tilastokeskus-kartta.swgis.fi/) (from 2018 onwards). 
+
+The data include municipality-based statistical areas, Paavo postcode areas, educational institutions, industrial and production facilities, and road traffic accidents. 
+
+As statistical data, the service includes population data by municipality-based statistical areas and statistical grids (1 km x 1 km and 5 km x 5 km). All map layers can be found as both WFS and WMS web services.
+
+In the map service, it is also possible to make statistical thematic maps. The available statistical data behind is the Municipal Key Figures service data used via PX-Web API. In addition to thematic maps, it is also possible to view data as time series.
+The service also has a Download Basket function, which allows you to download geospatial data sets for yourself.
+
+# Enthusiasm towards open source and joint development
+
+Statistics Finland has been involved in the Oskari network since the beginning. Supporting joint development and favoring open source solutions are also Statistics Finland's objectives. 
+
+Statistics Finland chose purchasing the service from a service provider. Sitowise Ltd has done work in building the service, but the intention is to utilise also other Oskari development companies in the future. 
+
+# What's next?
+
+The publishing system of Statistics Finland's website will be reformed. The goal is to incorporate the Oskari RPC solution into web pages when it is only technically and content-wise possible. 
+
+Statistics Finland's map and geospatial needs are very diverse, so it is possible to include other technological solutions if this is seen necessary.
+
+Oskari is awesome and it is hoped that it will be better utilised in Statistics Finland's services as well. 
+
+In the case of large datasets, developing data standards to be interoperable with geospatial information technologies is a big challenge. Fortunately, that is also happening, so we are optimistic about the future!
+
+<img src="/img/statisticsfi_oskari.png" class="img-responsive"/>
+
+<img src="/img/statisticsfi_oskari2.png" class="img-responsive"/>
+
+More information:
+Rina Tammisto
+Statistics Finland
+
+
+

--- a/_content/blog/2020-06-17-UI_facelift.md
+++ b/_content/blog/2020-06-17-UI_facelift.md
@@ -4,7 +4,7 @@ title:  "Oskari user interface face lift"
 excerpt : "Oskari UI (user interface) is developed and renewed with joint funding."
 date:   2020-06-17 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Oskari user interface is to be given a face lift

--- a/_content/blog/2020-06-17-UI_facelift.md
+++ b/_content/blog/2020-06-17-UI_facelift.md
@@ -4,6 +4,7 @@ title:  "Oskari user interface face lift"
 excerpt : "Oskari UI (user interface) is developed and renewed with joint funding."
 date:   2020-06-17 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Oskari user interface is to be given a face lift

--- a/_content/blog/2020-06-17-UI_facelift.md
+++ b/_content/blog/2020-06-17-UI_facelift.md
@@ -1,0 +1,32 @@
+---
+layout: post
+title:  "Oskari user interface face lift"
+excerpt : "Oskari UI (user interface) is developed and renewed with joint funding."
+date:   2020-06-17 13:00:00 +0300
+categories: [news]
+---
+
+# Oskari user interface is to be given a face lift
+
+It was proposed by Oskari developers and community, that Oskari should be brought to the 2020s with a new UI, so now the issue is at hand. Oskari UI (user interface) is to be slightly developed and renewed.
+   
+NLS (National Land Survey of Finland) did a service design of Oskari in late 2019, which works as a base for the UI update. 
+The plan includes new graphics for menus and icons as well as improved layout design. 
+
+The plan also has recommendations for available tools, including repositioning, clarifying and removing obsolete ones. 
+
+<img src="/img/layout_design.png" class="img-responsive"/>
+
+*Picture 1: New layout design* 
+ 
+The development will be a joint purchase with participants from City of Tampere, Statistics Finland, HSY (Helsinki Region Environmental Services Authority) and Lounaistieto. NLS-FI will be in commenting and advisory role with the chosen supplier. 
+
+Request for quotation also includes optional improvements in forms, combining measuring ad drawing tools and revising search tool. 
+
+The goal of the project is to produce new UI for Oskari therefore increasing the market value of Oskari and provide better user experience. The update is planned to finish by the end of 2020. 
+
+Read the [issue in GitHub](https://github.com/oskariorg/oskari-docs/issues/110)
+
+<img src="/img/sidepanel.png" class="img-responsive"/>
+
+*Picture 2: Collapsed side panel* 

--- a/_content/blog/2020-08-28-Hi_from_communication.md
+++ b/_content/blog/2020-08-28-Hi_from_communication.md
@@ -1,0 +1,71 @@
+---
+layout: post
+title:  "Hi from communication!"
+excerpt : "I have been privileged to participate in the communication coordination of Oskari software for the past three years. Gosh, how the time flies!"
+date:   2020-08-28 13:00:00 +0300
+categories: [news]
+---
+
+
+# Hello and thanks for all the fish - I mean thank you Oskari community!
+
+I have been privileged to participate in the communication coordination of Oskari software for the past three years. Gosh, how time flies! 
+The job is soon to be passed on to someone else and I’m happy to see that Oskari is currently being used in various instances and use cases. The Community is in a good state.
+
+My path with Oskari actually started about ten years ago, when I was coordinating the activities of regional SDI in Southwest Finland. 
+At that time at the national level they started to develop a rival service for our lonesome geoportal  - the national SDI and national geoportal called Paikkatietoikkuna. 
+In 2014 I had to give up and surrender to the governmental forces and we adopted Oskari as the tool for providing regional viewing services for the hundreds of GIS data collected from the region. 
+
+## Oskari was the first mature open source map services I encountered
+
+At that point Oskari was one of the first open source geoportals that was mature enough to support the needs of the EU's INSPIRE-directive (providing a view service for WMS/WFS map layers with integration to metadata service).
+It was also the first open source web map services I came across where you did not have to build everything from scratch from tens of different components. 
+
+When I started working for Gispo Ltd in 2016 my first biggest assignment for the National Land Survey of Finland was to tackle the “problem” of openness. 
+You know, when the source code is open, it does not necessarily mean that it is accessible or openly communicated to everyone. 
+So my job was to check how we could together with the Oskari network (established in 2014, now-a-days called the Oskari community) steer Oskari into a more open development 
+and more known open source solution used also outside Finland. After the first assignment I was commissioned to continue and help with Oskari communication coordination activities for the Joint Development Forum of Oskari.
+
+## From semi-open to fully open
+
+Back then Oskari was in my opinion semi open: the source code was licensed correctly, but the communication between stakeholders was mainly done in Finnish in closed channels, 
+the developers had not signed the Contributor License Agreement and hence the source code could have encountered some IPR challenges. 
+Also there were some bureaucratic hindrances that affected how to contribute, who could be part of the community and what are the roles of different groups and users. 
+And above all, there was a lingering question about who does what and how the source code is managed.
+
+This all might seem a bit trivial, since the product itself could be used and further developed openly already then. 
+But I find that we need some rules and protocols at least when dealing with a huge software with multiple organisations involved. 
+At least we need to say how the source code should be created and what are the procedures for including the code to the core and in some cases, why the code is _not_ to be added to the core. 
+[OSGeo Foundation incubation process checklist](https://wiki.osgeo.org/wiki/Incubation_Committee) was very useful for this process and it provided Oskari the tools to become a more open product. 
+Although Oskari is still waiting for the verdict from OSGeo, the tasks we had to take for the incubation process were pushing Oskari to the right direction. 
+We have now rules and guidelines on how to contribute and what is the role and tasks of the Project Steering Committee that all open source projects should have. 
+So this process has been very valuable for the Oskari community. 
+
+## If you are not familiar with the open source codes of conduct, here is a tip-list
+
+- First when you get an idea or need to improve Oskari (or in fact whatever open source solution), you should ask around if someone else has encountered the same problem. 
+- If it is a bug, you should report it as a GitHub issue in detail: when did this happen, with what version and environment and what exactly happened, were you able to produce the same error multiple times and are you able to fix it yourself. 
+- If it is an enhancement idea, you should describe it well and provide information if your organization (or multiple organizations) is willing to finance or build it.
+- You can also just leave an open idea as an GitHub issue, but if there is no-one to proceed with it, it may very well stay there as an issue forever. 
+- And ask. Always ask if you have something in your mind. This is usually very problematic for us Finns! 
+- And finally, like in all open source projects it would be good that every time a new tool or feature is created, some (I mean a lot) of the efforts should be allocated to documentation and enhancements in the core product. 
+
+## Understanding how open source works
+
+This is something that I think was the problem with most open source projects a few years ago. The procedure for how to build open source solutions was not clear for all the users or project owners and some of them were just waiting for somebody somewhere who would enhance the products for free. Don’t get me wrong, it is totally ok just to wait for the next release and use it as it is and never chip in code wise. But if you want something done, you usually need to pay or do it yourself. So if you are still yelling: THIS DOES NOT WORK! You should start yelling: WE HAVE RESOURCES, WE CAN FIX THIS! 
+
+I think the situation has changed and people are more actively developing the open tools they need and understand the procedures of open source better.
+
+## Oskari and friends
+
+Oskari is an open source geoportal software and In my opinion the best thing with it is the versatile and useful tools to create embedded maps. And the amount of Oskari based map service we have at the moment is staggering! Almost everywhere in the public sector in Finland you can see either Oskari installations or embedded maps created from them. Finland is the land of Oskari. Hope your country will come along soon!
+
+I wanted to thank all of you who have participated and actively developed Oskari especially those who attended meetups and geobeers! I have learned a lot and found really good new friends. Now it is time for someone else to continue with Oskari community coordination, I promise, I’ll be a good community member and don’t yell for someone else to fix things, at least not that much!
+
+Virtual Hugs from Southwest Finland, Turku
+
+*Sanna Jokela*
+
+*Former Oskari Communication coordinator*
+
+*Working with open source geospatial solutions at Gispo Ltd*

--- a/_content/blog/2020-08-28-Hi_from_communication.md
+++ b/_content/blog/2020-08-28-Hi_from_communication.md
@@ -4,6 +4,7 @@ title:  "Hi from communication!"
 excerpt : "I have been privileged to participate in the communication coordination of Oskari software for the past three years. Gosh, how the time flies!"
 date:   2020-08-28 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 

--- a/_content/blog/2020-08-28-Hi_from_communication.md
+++ b/_content/blog/2020-08-28-Hi_from_communication.md
@@ -4,7 +4,7 @@ title:  "Hi from communication!"
 excerpt : "I have been privileged to participate in the communication coordination of Oskari software for the past three years. Gosh, how the time flies!"
 date:   2020-08-28 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 

--- a/_content/blog/2021-06-15-Virma.md
+++ b/_content/blog/2021-06-15-Virma.md
@@ -4,6 +4,7 @@ title:  "Recreational site info website"
 excerpt : "Recreational site info app built with Oskari RPC (Finnish language version only)"
 date:   2021-06-15 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Virkistyskohdetietoa sisältävässä Virma Kartta -verkkosovelluksessa hyödynnetty OskariRPC-toiminnallisuutta

--- a/_content/blog/2021-06-15-Virma.md
+++ b/_content/blog/2021-06-15-Virma.md
@@ -4,7 +4,7 @@ title:  "Recreational site info website"
 excerpt : "Recreational site info app built with Oskari RPC (Finnish language version only)"
 date:   2021-06-15 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Virkistyskohdetietoa sisältävässä Virma Kartta -verkkosovelluksessa hyödynnetty OskariRPC-toiminnallisuutta

--- a/_content/blog/2021-06-15-Virma.md
+++ b/_content/blog/2021-06-15-Virma.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title:  "Recreational site info website"
+excerpt : "Recreational site info app built with Oskari RPC (Finnish language version only)"
+date:   2021-06-15 13:00:00 +0300
+categories: [news]
+---
+
+# Virkistyskohdetietoa sisältävässä Virma Kartta -verkkosovelluksessa hyödynnetty OskariRPC-toiminnallisuutta
+
+(Finnish language version only)
+
+<img src="/img/virma/img1.jpg" class="img-responsive" style="float:right; margin-left: 20px; border-radius: 3%;" /> Varsinais-Suomen virkistyskohteita ja -reittejä on viime vuosien aikana koottu digitaaliseksi aineistoksi Varsinais-Suomen liiton ylläpitämään karttapohjaiseen Virma Ylläpito -palveluun. Palvelu ei kuitenkaan ole mahdollistanut mobiilikäyttöä, vaan se on tarkoitettu lähinnä ylläpitoon tai kohteiden tarkasteluun. Tähän on nyt tullut kaivattu muutos: samaa Virma-aineistoa hyödyntäen on kehitetty täysin uusi karttapalvelu, <a href="https://kartta.virma.fi" target="_blank">Virma Kartta</a>. Se on optimoitu erityisesti mobiilikäyttöön eli tietoja voi hyödyntää käyttäjäystävällisesti myös maastossa älypuhelimen avulla!
+
+Virma Kartta on täysin ilmainen ja suunniteltu erityisesti retkeilijöiden käyttöön. Palvelu mahdollistaa esimerkiksi oman sijainnin tai lähistöllä sijaitsevien matkailupalveluiden tarkastelun reitin varrella tai kohteen varustetason tarkastamisen. Karttapalveluun on koottu jo yli 1000 retkikohdetta Varsinais-Suomesta. Virkistyskohteiden ja -reittien visualisoinnissa on panostettu käyttäjäystävällisyyteen.
+
+Virma Kartta on toteutettu verkkosovelluksena, eli karttapalvelua käytetään älypuhelimen selaimessa, eikä käyttäjän tarvitse ladata erillistä sovellusta. Toteutustavassa päädyttiin verkkosovellusratkaisuun muun muassa teknisen ylläpidon yksinkertaisuuden vuoksi. Sovellus on toteutettu avoimen lähdekoodin ohjelmistokehyksiä ja -kirjastoja hyödyntämällä. Sovelluslogiikka on tehty Javascriptillä käyttäen Vue.js sekä Vuetify -kirjastoja. Karttanäkymä puolestaan on toteutettu OskariRPC:llä. OskariRPC:hen päädyttiin muun muassa siksi, että sen kehittämisestä vastaavat pääosinsuomalaiset paikkatietoammattilaiset ja sen integraatio <a href="https://karttapalvelu.lounaistieto.fi/" target="_blank">Lounaistiedon karttapalvelu</a>n kanssa helpottaa ylläpitoa huomattavasti.
+
+Oskari-alusta mahdollistaa mobiilikäytön lisäksi myös monia muita ominaisuuksia. Se sisältää toimintoja niin perus- kuin ammattikäyttäjillekin: esimerkiksi karttajulkaisutoiminnon avulla Oskarista voi tehdä karttaupotuksia organisaatioiden verkkosivuille. Lounaistiedon karttapalvelusta voi Virma-aineistosta tehtäviin karttaupotuksiin liittää mukaan myös muita karttatasoja, kuten bussipysäkkidataa. Oskarin kartta-alustaa hyödynnetään Lounaistiedon alueellisen karttapalvelun lisäksi myös muun muassa kansallisessa <a href="https://kartta.paikkatietoikkuna.fi" target="_blank">Paikkatietoikkuna-karttapalvelussa</a>.
+
+Virma-aineistolla on siis monta jakelukanavaa: se on saatavilla Virma Ylläpito -palvelun ja Virma Kartta -verkkosovelluksen lisäksi avoimena datana myös Lounaistiedon dataportaalin ja karttapalvelun kautta. Aineisto on täysin ilmaista, avointa ja kaikkien hyödynnettävissä. Sillä onkin monenlaista jatkokehittämispotentiaalia: koska sekä data että lähdekoodi on julkaistu avoimena, on niiden pohjalta mahdollista kehittää myös uusia sovelluksia tai laajentaa palvelua muihinkin maakuntiin.
+
+Virma-palvelua kehitetään Digitaalisen saavutettavuuden parantaminen virkistyspalveluissa (Digisaapas) -hankkeessa, joka on osa Manner-Suomen maaseudun kehittämisohjelmaa. Hanke on kolmevuotinen ajalla 2020 –2022. Hankkeen toteuttajia ovat Lounaistiedon lisäksi Varsinais-Suomen liitto, Valonia, ProAgria Länsi-Suomi ja Maa- ja kotitalousnaiset sekä Turun yliopiston Teknillisen tiedekunnan Tietotekniikan laitos. Hankkeen kohderyhminä ovat mm. kunnat, matkailutoimijat ja muut yritykset, yhdistykset, muut kohteiden ylläpitäjät sekä retkeilijät.
+
+<img src="/img/virma/img2.jpg" class="img-responsive" style="border-radius: 2%;" />

--- a/_content/blog/2022-06-07-Indonesia.md
+++ b/_content/blog/2022-06-07-Indonesia.md
@@ -4,7 +4,7 @@ title:  "Case Indonesia: Oskari can help utilizing spatial data anywhere!"
 excerpt : "The World Bank, in close collaboration with Sitowise, designed and implemented a new kind of data solution that aims at helping local government agencies and other parties in Indonesia to make use of the vast amount of data available from different sources."
 date:   2022-06-07 12:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Case Indonesia: Oskari can help utilizing spatial data anywhere!

--- a/_content/blog/2022-06-07-Indonesia.md
+++ b/_content/blog/2022-06-07-Indonesia.md
@@ -4,6 +4,7 @@ title:  "Case Indonesia: Oskari can help utilizing spatial data anywhere!"
 excerpt : "The World Bank, in close collaboration with Sitowise, designed and implemented a new kind of data solution that aims at helping local government agencies and other parties in Indonesia to make use of the vast amount of data available from different sources."
 date:   2022-06-07 12:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Case Indonesia: Oskari can help utilizing spatial data anywhere!

--- a/_content/blog/2022-06-07-Indonesia.md
+++ b/_content/blog/2022-06-07-Indonesia.md
@@ -1,0 +1,36 @@
+---
+layout: post
+title:  "Case Indonesia: Oskari can help utilizing spatial data anywhere!"
+excerpt : "The World Bank, in close collaboration with Sitowise, designed and implemented a new kind of data solution that aims at helping local government agencies and other parties in Indonesia to make use of the vast amount of data available from different sources."
+date:   2022-06-07 12:00:00 +0300
+categories: [news]
+---
+
+# Case Indonesia: Oskari can help utilizing spatial data anywhere!
+
+Oskari has been developed for quite some time now and it already has a lot of satisfied users. Many different organizations in Finland have utilized and understood the potential of this map framework for their spatial data needs and have taken the latest and greatest features of Oskari in use.
+
+Sitowise offers a wide variety of services that make use of Oskari. We have had the privilege and opportunity to take part in the development of the framework. We have seen how different organizations can benefit from the features that Oskari offers. Lately, we have also had a great opportunity to take Oskari abroad, so to speak, as we were part of a project that aimed at making spatial (and other) data more available and accessible in Indonesia.
+
+## What is Satu Data Portal?
+
+The World Bank, in close collaboration with Sitowise, designed and implemented a new kind of data solution that aims at helping local government agencies and other parties in Indonesia to make use of the vast amount of data available from different sources. Because of the many abilities and maturity of Oskari it was selected to be used as the geoportal part in the architecture of this data portal solution called Satu Data Portal (or One Data Portal in English). And because openness and Open Source in general were one of the key requirements for the system, Oskari was an ideal fit for the job.
+
+While Oskari works in the implemented solution as the geoportal, it was decided to use another widely known Open-Source solution, CKAN, as the data portal part of the architecture. During the project Sitowise implemented an integration between the two systems and designed the server infrastructure in close collaboration with a local partner, Geo Enviro Omega, in Indonesia. In addition, we worked closely with a company called CAPSUS in Mexico. CAPSUS created a set of advanced analysis tools on top of Oskari. These tools were integrated into the Satu Data Portal seamlessly.
+
+In a nutshell, Satu Data Portal utilizes CKAN as the main interface for storing and viewing information and metadata about basically any data (including spatial data). When the stored data is spatial data, e.g., an OGC Web Service API or actual data files (shapefile or GeoJSON), it will be published to the geoportal with an automated process built specifically for this solution. This enables the users to visualize and view their data on a map in Oskari and make use of all the tools Oskari provides without the need to maintain the spatial data in two different places manually.
+
+The key features of the Satu Data Portal solution were:
+* Portal for viewing, analyzing, combining, and publishing spatial & non-spatial data
+* Integrates with national level and local data and services
+* Access & user group management
+* Aligned with defined processes, roles & responsibilities
+* Open Source (based on Oskari.org & CKAN framework), open & standard API’s
+
+## Thoughts about Oskari overseas 
+
+The project was interesting and included a trip (well, several, but one of which I was lucky enough to join) to Indonesia where we got to present our solution to various government agencies, representatives of two different cities (Balikpapan in Borneo and Denpasar in Bali) and a variety of other parties in Jakarta. Oskari raised a lot of interest and was well received. There was a lot of discussion about how impressive it is that we have this kind of Open-Source solution developed by the National Land Survey of Finland. And because it was an integral part of the project to provide a solution that the cities and other parties would be able to maintain and develop even further themselves, the active developer community of Oskari was also welcomed with open arms.
+
+I personally think this project made it clear that there is much need for the kind of well-made, mature, and actively maintained Open-Source geoportal solution that Oskari is, even world-wide. By spreading the word about Oskari and its abilities, there are almost endless possibilities for the framework in the future. Not to mention how cool it is that we can widen our community beyond the borders of Finland.
+
+By: Jani Levonen

--- a/_content/blog/2022-10-24-FOSS4G.md
+++ b/_content/blog/2022-10-24-FOSS4G.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title:  "Oskari at FOSS4G"
+excerpt : "Oskari recently enjoyed international attention. The limelight was, of course, shed upon Oskari at FOSS4G in Florence."
+date:   2022-10-24 14:00:00 +0300
+categories: [news]
+---
+
+# Oskari at FOSS4G
+
+Oskari recently enjoyed international attention. The limelight was, of course, shed upon Oskari at FOSS4G in Florence. FOSS4G is the annual recurring global event hosted by [OSGeo](https://www.osgeo.org/), the non-profit organization that supports and promotes the collaborative development of free and open-source geographic technologies and open geospatial data. 
+
+Oskari was presented at the event on several occasions in August. First, Oskari was demonstrated in a half-day workshop on the first day of the event, as well as in two separate presentations that were held later in the week. 
+
+<img src="/img/fossg4g2022/ws1.jpg" class="img-responsive" style="border-radius: 2%;" />
+
+The workshop focused on the ease of building a web-based service with an integrated map component. There were more than 10 participants in the workshop. “It was very nice to see such an international and diverse group of participants“, states the workshop facilitator Timo Aarnio, a Senior GIS Expert. The workshop participants tried themselves how to use Oskari embedded maps. For enthusiasts who wish to try it too, the workshop materials are a mere click away: [Oskari workshop materials](https://oskari.org/documentation/examples/FOSS4G_2022/workshop).
+
+The "state of Oskari" -presentations were divided in two parts: the first part dealt with functionalities for end-users and administrators. The presented new functionalities included new styling tools, map layer analytics and diagnostics tools among others. 
+
+The other "state of Oskari" -presentation focused on the technical developments in Oskari and was targeted to a developer audience. "It was a pleasure to present these new features to our international colleagues,” says Senior IT Specialist Sami Mäkinen from the National Land Survey of Finland. “We have recently made some major improvements and created new features and functionalities in cooperation with partners like the Finnish Transport Infrastructure Agency". You can read [Sami's presentation here](https://zakarfin.github.io/oskari_foss4g_2022/).
+
+<img src="/img/fossg4g2022/pres.jpg" class="img-responsive" style="border-radius: 2%;" />

--- a/_content/blog/2022-10-24-FOSS4G.md
+++ b/_content/blog/2022-10-24-FOSS4G.md
@@ -4,6 +4,7 @@ title:  "Oskari at FOSS4G"
 excerpt : "Oskari recently enjoyed international attention. The limelight was, of course, shed upon Oskari at FOSS4G in Florence."
 date:   2022-10-24 14:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 
 # Oskari at FOSS4G

--- a/_content/blog/2022-10-24-FOSS4G.md
+++ b/_content/blog/2022-10-24-FOSS4G.md
@@ -4,7 +4,7 @@ title:  "Oskari at FOSS4G"
 excerpt : "Oskari recently enjoyed international attention. The limelight was, of course, shed upon Oskari at FOSS4G in Florence."
 date:   2022-10-24 14:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 
 # Oskari at FOSS4G

--- a/_content/blog/2023-02-13-PSC_February2023.md
+++ b/_content/blog/2023-02-13-PSC_February2023.md
@@ -4,6 +4,7 @@ title:  "February meeting 2023"
 excerpt : "PSC members changes, roadmap items, software updates"
 date:   2023-02-13 14:00:00 +0300
 categories: [psc, psc-memo]
+tags: [blog]
 ---
 
 # February meeting 2023

--- a/_content/blog/2023-02-13-PSC_February2023.md
+++ b/_content/blog/2023-02-13-PSC_February2023.md
@@ -1,0 +1,90 @@
+---
+layout: post
+title:  "February meeting 2023"
+excerpt : "PSC members changes, roadmap items, software updates"
+date:   2023-02-13 14:00:00 +0300
+categories: [psc, psc-memo]
+---
+
+# February meeting 2023
+
+The PSC gathered to discuss the following agenda:
+
+- PSC member changes
+- News from the members
+- Java/NodeJS updates
+
+## Opening the meeting at 14:08
+
+Via conference call:
+
+- Sami Mäkinen
+- Timo Sallinen
+- Marko Kuosmanen
+- Janne Heikkilä
+- Oskari Rintamäki
+
+Not present:
+
+- Jussi Arpalahti
+- Anniina Kovalainen
+
+## PSC member changes
+
+- Janne Heikkilä, Anniina Kovalainen were elected to be new PSC members
+- Hafliði Sigtryggur Magnússon requested to step down from PSC
+
+## Recent Oskari development
+
+Initial theme support:
+- https://github.com/oskariorg/oskari-frontend/pull/1871
+- https://github.com/oskariorg/oskari-frontend/pull/2069
+- https://github.com/oskariorg/oskari-frontend/pull/2099
+- https://github.com/oskariorg/oskari-frontend/pull/2100
+
+Base HTML rewrite:
+- https://github.com/oskariorg/oskari-frontend/pull/2042
+- https://github.com/oskariorg/sample-server-extension/pull/35
+
+## Software updates
+
+### PostgreSQL
+
+Discussion about updating Flyway to support more recent PostgreSQL versions approved. After updating Oskari will require PostgreSQL 11+ (https://github.com/oskariorg/oskari-server/pull/915).
+
+### Node JS
+
+We will be updating Node JS required version to 16 in the near future.
+
+### Java
+
+Currently Oskari requires Java 8 for builds. No compile errors with Java 11, but annotated classes don't work if built with 11. Discussion if we should update minimum required version to 17 instead of 11 so we could use the language features enabled by newer version.
+
+Sami sends a query to mailing list for additional input on the matter and this will be discussed on the next meeting.
+
+## Oskari.org documentation
+
+Discussed the possibility to move technical documentation from oskari-docs/oskari.org to GitHub in the source repositories (oskari-frontend/oskari-server). Some of the docs like frontend bundles etc are already there, but we can provide a better UI to see these when generating the docs to oskari.org site. This is related to work towards rewriting/re-structuring the oskari.org site.
+
+## Roadmap
+
+Roadmap items: https://github.com/oskariorg/oskari-docs/labels/roadmap
+
+Some fairly old ones listed. Discussed about having a "waiting for resources" label on roadmap items that are interesting but have not progressed. Better to just add a comment about current thoughts and status on them.
+
+Updated current status for:
+- https://github.com/oskariorg/oskari-docs/issues/28
+- https://github.com/oskariorg/oskari-docs/issues/82
+- https://github.com/oskariorg/oskari-docs/issues/110
+- https://github.com/oskariorg/oskari-docs/issues/200
+- https://github.com/oskariorg/oskari-docs/issues/31
+- https://github.com/oskariorg/oskari-docs/issues/35 -> closed as there is no current use case for this.
+- https://github.com/oskariorg/oskari-docs/issues/32
+- https://github.com/oskariorg/oskari-docs/issues/17
+- https://github.com/oskariorg/oskari-docs/issues/282 -> included in 2.10
+
+## Next meeting
+
+Next meeting: in April, a doodle poll will be sent by Sami
+
+## End of meeting: 15:05

--- a/_content/blog/2023-02-13-PSC_February2023.md
+++ b/_content/blog/2023-02-13-PSC_February2023.md
@@ -4,7 +4,7 @@ title:  "February meeting 2023"
 excerpt : "PSC members changes, roadmap items, software updates"
 date:   2023-02-13 14:00:00 +0300
 categories: [psc, psc-memo]
-tags: [blog]
+tags: blog
 ---
 
 # February meeting 2023

--- a/_content/blog/2023-04-11-Roadmap2023.md
+++ b/_content/blog/2023-04-11-Roadmap2023.md
@@ -4,7 +4,7 @@ title:  "Roadmap 2023"
 excerpt : "Things about what's new and what are the biggest things planned for this year."
 date:   2023-04-21 13:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 # Roadmap 2023
 

--- a/_content/blog/2023-04-11-Roadmap2023.md
+++ b/_content/blog/2023-04-11-Roadmap2023.md
@@ -4,6 +4,7 @@ title:  "Roadmap 2023"
 excerpt : "Things about what's new and what are the biggest things planned for this year."
 date:   2023-04-21 13:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 # Roadmap 2023
 

--- a/_content/blog/2023-04-11-Roadmap2023.md
+++ b/_content/blog/2023-04-11-Roadmap2023.md
@@ -1,0 +1,55 @@
+---
+layout: post
+title:  "Roadmap 2023"
+excerpt : "Things about what's new and what are the biggest things planned for this year."
+date:   2023-04-21 13:00:00 +0300
+categories: [news]
+---
+# Roadmap 2023
+
+We have started the year strong by rewriting most of the tools which are visible on the map. These are already available in the oskari-frontend in version 2.10. This has also given us the opportunity to improve theming support in Oskari. Now the colors and rounding of the buttons on the map (and popups which they open) can be modified by using theming. This is an especially strong feature for the publisher functionality. We have also improved styling tools on the publisher functionality to make it easier for end-users to match styling of the controls on the map with the page the map will be used on. You can see these changes already in [https://demo.oskari.org](https://demo.oskari.org).
+
+There are also other major changes that have happened "in the engine room", such as overhauling the HTML/DOM structure that Oskari builds on (also available on Oskari 2.10). This enables us to better serve users with small screen sizes and/or mobile devices and makes it easier to customize the page around Oskari functionalities for a more personalized geoportal. We have added a new example on our sample-application to demonstrate this. This is an important milestone towards mobile friendliness for the geoportal. It doesn't mean that we have completed our goals, or even started really for mobile users, but it is an awesome starting point for what we can now start building on.
+
+<div style="display: flex; justify-content: space-between;">
+    <a href="/img/2023/demo.png"><img src="/img/2023/demo.png" class="img-responsive" alt="Light themed geoportal" style="border-radius: 2%;padding: 2em;"></a>
+    <a href="/img/2023/light.png"><img src="/img/2023/light.png" class="img-responsive" alt="Light themed geoportal" style="border-radius: 2%;padding: 2em;"></a>
+    <a href="/img/2023/stylized.png"><img src="/img/2023/stylized.png" class="img-responsive" alt="Light themed geoportal" style="border-radius: 2%;padding: 2em;"></a>
+</div>
+ 
+The embedded maps have been mobile friendly for years already, but we have made some changes to those as well. Previously we used something that we called "a mobile toolbar”. This meant that tools on the map would move to a toolbar on top of the map when there's limited screen space available. In consequence, even with a single button (or two) on the map, we reserved a full button row of screen space for the "mobile toolbar". We realized this makes the toolbar take up more space from the map instead of saving it in most cases. In addition, the toolbar was problematic for styling around on the embedding page. 
+
+For these reasons we have removed the concept of "mobile toolbar". Instead, the buttons/controls on map can now adapt to smaller screen size. The zoombar, for example, removes the "bar" and only keeps the buttons etc.
+
+In the future we can do even more to improve these. We could, for example, make the buttons collapse into a menu depending on the screen space that is available. This change applies to the geoportal as well as it is essentially the same kind of application as embedded maps, but with more functionalities and an added navigation bar. 
+ 
+## Upcoming changes
+ 
+With the improvements and "standardization" of the controls on the map, we have started working on improving the developer experience for the map plugins. This means streamlining the API and making it clearer what the extension points are and how the plugins interact with and are updated by the map module/bundle. This also affects how map plugins work with the publisher functionality.
+
+As we are migrating more and more functionalities from jQuery to React, we have also implemented few of the tools (in Oskari 2.11) for publisher functionality using React.js. This has also allowed us to spend some time on figuring out improvements for the API for publisher tools. The tools in publisher now handle the plugins in the same way as they are started on embedded maps. This makes it easier to detect possible errors and has allowed us to remove duplicated code regarding the publisher functionality. For example, in the upcoming 2.11 Oskari release, the map plugins no longer need to care about the drag-n-drop functionality in the publisher. It is handled completely by the publisher, making the code on the plugins cleaner and adding a publisher tool for a plugin is now a breeze.
+ 
+Note that application specific bundles have "always" had the opportunity to add more options for the user that are shown on the publisher UI and these might need some updating to make them compatible with the next release ([docs link](https://oskari.org/documentation/features/publisher/tools)). The same applies for map plugins. The deprecated "mobile toolbar" concept used the plugin function `redrawUI()` and most bundles should be ok by renaming it to `refresh()` (this is an existing function in the plugin API) and possibly adding a `_startPluginImpl()` function that generates the UI if redrawUI was used before for that:
+ 
+- [docs link: map](https://oskari.org/documentation/features/map)
+- [docs link: map plugin](https://oskari.org/documentation/features/map/mapplugin)
+ 
+Finally, some things that actual users might recognize for the next release: the map layers panel on publisher has been rewritten. It now uses existing functionality to handle layer operations and most of the tools regarding map layers have been moved from the generic tools panel to the map layers panel. In short, it looks nicer and hopefully is more user friendly as well. You can see these changes already in [https://dev.oskari.org](https://dev.oskari.org).
+ 
+Another upcoming change for end users is the ability to save map layer styling for vector layers! Previously end-users could add a style for vector layer at runtime, but the styling was lost on page reload. This also meant that the styles could not be used in embedded maps. As the default style looks... well, by definition "default", it looks the same for _all_ of the vector layers where the admin has not specifically generated a style for the layer. This makes it hard for users to use vector layers as they all look the same and are not easily recognizable from each other.
+ 
+A smaller detail is that the SearchPlugin that can be added to embedded maps have been improved by adding functionality to it to match or even exceed the default search UI on geoportal. This makes it just plain better for users of embedded maps, but it now is a viable option to replace the current search user interface with the search field that is shown on top of the map. You can see this demonstrated in [https://dev.oskari.org](https://dev.oskari.org).
+ 
+Last thing in this segment is throwing in some more love for developers and I'm pleased to say you can now use NodeJS 16 with Oskari. Using a more recent NodeJS is currently blocked by our dependency for `node-sass`. As we are currently using `styled-components` for any new styling we are slowly migrating away from SCSS files and node-sass. But for now (in Oskari 2.11) you can safely use NodeJS 16.
+ 
+## Going forward
+ 
+Let’s start this off by saying that our current single largest development target for Q3/Q4 2023 is working towards merging the myplaces and userlayer (and possibly analysis) functionalities. This would mean that end-users could edit features that have been imported from a file to the geoportal and/or import "myplaces" from a file (as these would be the same thing). This could also mean that users can edit what the feature properties are for these layers (not just the values/currently myplaces is a fixed set of properties). Additionally, it gets rid of the concept of multiple user generated content sources that can sometimes be confusing to end-users (why can I edit this feature, but not this other one etc). This also allows us to look at performance for the user generated content. We are likely to move away from bundling the GeoServer application with the Oskari sample application and just query the database directly for these.
+ 
+We also continue improving the mobile experience for the geoportal. The first task is to make the "flyout windows" in Oskari respect the screen size. This means that they wouldn't open outside the browser viewport and should be movable by touch events. Another thing for advancing this is solving how the navigation bar should behave with limited screen space. One option is a toggle that could be used minimize the navigation bar. We have some concept images how this could work.
+ 
+For developers/maintainers, Oskari pretty much needs to be compiled using Java 8 currently. While it compiles with newer Java versions, some things don't work properly. The runtime can be a newer version, but we want to upgrade it for compiling as well. We are likely to drop support for Java 8 and are looking into having the minimum version for compiling Oskari to be either Java 11 or 17.
+ 
+That's all for now, thanks for reading!
+ 
+    Sami / zakarfin @ GitHub

--- a/_content/blog/2023-06-20-Version_2_11.md
+++ b/_content/blog/2023-06-20-Version_2_11.md
@@ -4,7 +4,7 @@ title:  "Version 2.11"
 excerpt : "A new version of Oskari is out! You can now save your own styles on map layers and use them on published maps."
 date:   2023-06-20 12:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 # A new version of Oskari is out!
 

--- a/_content/blog/2023-06-20-Version_2_11.md
+++ b/_content/blog/2023-06-20-Version_2_11.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title:  "Version 2.11"
+excerpt : "A new version of Oskari is out! You can now save your own styles on map layers and use them on published maps."
+date:   2023-06-20 12:00:00 +0300
+categories: [news]
+---
+# A new version of Oskari is out!
+
+Summer has come in a flash and the much-anticipated summer holidays are just around the corner for many. We are happy to announce that with summer, the latest version of Oskari has now been released! The updated **Oskari 2.11** brings with it many improvements. 
+
+The new Oskari 2.11 makes building web maps and displaying and analyzing geospatial data smoother than ever. Under the hood, the database libraries have also been updated, enabling newer PostgreSQL versions to be used.
+
+**What changes did the new version bring?**
+
+- **Storage of map layer styles.** You are able to save your own styles to the vector layer for later use. Saved custom styles can be found in the My Styles tab and can be used in previously published maps. 
+- **More scalable mobile version:** Oskari will switch to mobile view when the screen width or height is less than 650 pixels. In the mobile version, the content of the windows has been modified to be more scalable to the small screen. Windows that are used in desktop mode, fill the entire screen on mobile mode. And for example when searching with the window based UI, in the mobile version, once the user selects a search result, the search window closes, and the search result is displayed on the map. 
+- **The search functionality** on published maps has been improved.
+- **Saving map layer styles:** users can save their own style on vector layers for later use. Custom styles can also be used on published maps. Custom styles can be found in the My Styles tab.
+- **The tool options in the map editor have been redesigned.** For example, selections related to map layers are now grouped in the Map Layers menu. Tools available only through programmatic access are selected from the "Programmatic access (RPC interface)" menu. 
+- In addition to the above changes, the latest version of Oskari includes minor updates and improvements, such as changes to maintenance tools, time series, map layer comparison tools, user tool tips, etc. 
+
+You can find out more about the changes on the Oskari.org GitHub site. The latest version is 2.11.0.
+
+Release notes:
+ - [oskari-frontend](https://github.com/oskariorg/oskari-frontend/blob/master/ReleaseNotes.md#2110)
+ - [oskari-server](https://github.com/oskariorg/oskari-server/blob/master/ReleaseNotes.md#2110)
+ 

--- a/_content/blog/2023-06-20-Version_2_11.md
+++ b/_content/blog/2023-06-20-Version_2_11.md
@@ -4,6 +4,7 @@ title:  "Version 2.11"
 excerpt : "A new version of Oskari is out! You can now save your own styles on map layers and use them on published maps."
 date:   2023-06-20 12:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 # A new version of Oskari is out!
 

--- a/_content/blog/2023-08-23-Community_Day.md
+++ b/_content/blog/2023-08-23-Community_Day.md
@@ -4,6 +4,7 @@ title:  "Oskari day 5.6.2023"
 excerpt : "Community is a core value of Oskari. Everyone is welcome to participate in the development of Oskari. The Oskari community came together in June to network and share their learnings and ideas on Oskari Day."
 date:   2023-08-23 12:00:00 +0300
 categories: [news]
+tags: [blog]
 ---
 # The Oskari community came together for Oskari Day 5.6.2023
 

--- a/_content/blog/2023-08-23-Community_Day.md
+++ b/_content/blog/2023-08-23-Community_Day.md
@@ -4,7 +4,7 @@ title:  "Oskari day 5.6.2023"
 excerpt : "Community is a core value of Oskari. Everyone is welcome to participate in the development of Oskari. The Oskari community came together in June to network and share their learnings and ideas on Oskari Day."
 date:   2023-08-23 12:00:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 # The Oskari community came together for Oskari Day 5.6.2023
 

--- a/_content/blog/2023-08-23-Community_Day.md
+++ b/_content/blog/2023-08-23-Community_Day.md
@@ -1,0 +1,38 @@
+---
+layout: post
+title:  "Oskari day 5.6.2023"
+excerpt : "Community is a core value of Oskari. Everyone is welcome to participate in the development of Oskari. The Oskari community came together in June to network and share their learnings and ideas on Oskari Day."
+date:   2023-08-23 12:00:00 +0300
+categories: [news]
+---
+# The Oskari community came together for Oskari Day 5.6.2023
+
+Community is a core value of Oskari. Everyone is welcome to participate in the development of Oskari. The Oskari community came together in June to network and share their learnings and ideas on Oskari Day.
+
+The Oskari Community is a growing group of organisations, individuals and developers who are combining their interests to improve and develop the Oskari software. Members of the Oskari community openly share their skills and knowledge with each other and develop Oskari together. 
+
+Communication between the network is mostly virtual, but live meetings are also organised. 
+
+The Oskari community gathered in June for the annual Oskari Day in Pasila, Helsinki. The programme included free discussion, networking and exchange of experiences.
+
+## Oskari is an important tool for the City of Tampere 
+
+The Network Day included presentations on how different community organisations use Oskari. Jussi Tahvanainen shared the experiences of the City of Tampere and showed the participants an illustrative example of the functionality of the map service in practice. 
+
+The City of Tampere is one of the most long-term users of Oskari. The City of Tampere Map Service, based on Oskari, is a public view of the information the city provides to its citizens, but Oskari is also used internally by city officials. The use of Oskari has therefore spread widely across different departments in the city. Oskari is an important tool for many departments. 
+
+In total, the City of Tampere has around 1200 different map layers, of which 700 are public.
+
+## Southwestern Finland map service provides regional information on Southwest Finland
+
+Lounaistieto, the regional information service for south-west Finland, has also been using Oskar for several years. The map service hosts various geospatial datasets for the region of Southwest Finland.
+
+The map service allows users to view, for example, cycle paths in the area or the location of ancient monuments. 
+
+## Network members contributed to the website and branding redesign
+
+In addition to practical Oskari examples, the day also included a presentation by Sami Mäkinen from the National Land Survey of Finland, who explained and demonstrated updates to the latest version of Oskari. 
+
+The Oskari Day also included a presentation by Sitowise on the website and branding overhaul currently underway. The Oskari website will be redesigned to better serve users. During the Oskari Day, network members were given the opportunity to give feedback and comments on the website redesign. Network members were also invited to participate in a survey to identify Oskari's key brand messages and visual identity.
+
+

--- a/_content/blog/2023-08-23-FOSS4G_2023.md
+++ b/_content/blog/2023-08-23-FOSS4G_2023.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title:  "FOSS4G 2023, Kosovo"
+excerpt : "FOSS4G event is the world's largest gathering of open-source geospatial users, developers and researchers. The event showcased Oskari’s improvements to existing functionalities and new features introduced during the last year."
+date:   2023-08-23 12:30:00 +0300
+categories: [news]
+---
+# The Oskari map service was featured at the international FOSS4G event
+
+FOSS4G event is the world's largest gathering of open-source geospatial users, developers and researchers. The event showcased Oskari’s improvements to existing functionalities and new features introduced during the last year.
+
+In June, geospatial specialists from around the world came together again for the annual FOSS4G event. This year the event took place from 26 June - 2 July 2023 in Prizren, Kosovo.  
+
+FOSS4G (meaning Free and Open-Source Software for Geospatial) brought together again developers, users, decision-makers and observers from a broad spectrum of organizations and fields of operation. 
+
+The Oskari mapping service had a strong presence at the event. The presentations, which attracted an international audience, showcased, among other things, the development of Oskari over the past year.
+
+Sami Mäkinen from National Land Survey of Finland presented Oskari and its improvements to existing functionalities and new features introduced during the last year. In his presentation, Sami went through Oskari’s theme support, the UI rewrite progress and cloud compatibility improvements. 
+
+Oskari was also demonstrated in the presentation by Arto Sinkkonen from National Land Survey of Finland. Arto described with examples, how the Oskari platform and its features have been used to implement the Suomi.fi-maps service. 
+
+Arto presented the reasons why Oskari has proven to be the best solution for the Suomi.fi map service. Oskari’s benefits include, for example, its divided responsibility for organizations, low learning curve, low costs. In his presentation, Arto also talked about how Oskari supports open standards and data. 
+
+Timo Aarnio from Gispo Ltd also had a presentation about Oskari that demonstrated using embedded maps from Oskari and building different kinds of applications using the maps and controlling the map using the RPC API from the embedding page.
+
+Links to the presentations:
+- [State of Oskari by Sami](https://www.youtube.com/watch?v=8XosKFZAkdM&list=PLqa06jy1NEM2Kna9Gt_LDKZHv1dl4xUoZ&index=27)
+- [Suomi.fi-maps - national service implementation with Oskari platform by Arto](https://www.youtube.com/watch?v=5RzcOl95wFs&list=PLqa06jy1NEM2Kna9Gt_LDKZHv1dl4xUoZ&index=25)
+- [Oskari Embedded Maps and integrations with RPC API by Timo](https://www.youtube.com/watch?v=W9mNCarcpQs&list=PLqa06jy1NEM2Kna9Gt_LDKZHv1dl4xUoZ&index=28)

--- a/_content/blog/2023-08-23-FOSS4G_2023.md
+++ b/_content/blog/2023-08-23-FOSS4G_2023.md
@@ -4,6 +4,7 @@ title:  "FOSS4G 2023, Kosovo"
 excerpt : "FOSS4G event is the world's largest gathering of open-source geospatial users, developers and researchers. The event showcased Oskari’s improvements to existing functionalities and new features introduced during the last year."
 date:   2023-08-23 12:30:00 +0300
 categories: [news]
+tags: [blog]
 ---
 # The Oskari map service was featured at the international FOSS4G event
 

--- a/_content/blog/2023-08-23-FOSS4G_2023.md
+++ b/_content/blog/2023-08-23-FOSS4G_2023.md
@@ -4,7 +4,7 @@ title:  "FOSS4G 2023, Kosovo"
 excerpt : "FOSS4G event is the world's largest gathering of open-source geospatial users, developers and researchers. The event showcased Oskari’s improvements to existing functionalities and new features introduced during the last year."
 date:   2023-08-23 12:30:00 +0300
 categories: [news]
-tags: [blog]
+tags: blog
 ---
 # The Oskari map service was featured at the international FOSS4G event
 

--- a/_content/blog/test copy 2.md
+++ b/_content/blog/test copy 2.md
@@ -1,8 +1,0 @@
----
-title: Blog post
-date: 13.9.2023
-author: Oskari.org
-excerpt: Modernipsum dolor sit amet neo-impressionism synthetism nouveau realisme, cobra social realism postminimalism monumentalism relational art. Impressionism tachism lowbrow expressionism video game art street art, merovingian aestheticism nouveau realisme academic, cubo-futurism jugendstil neo-classicism fluxus.
----
-
-Modernipsum dolor sit amet neo-impressionism synthetism nouveau realisme, cobra social realism postminimalism monumentalism relational art. Impressionism tachism lowbrow expressionism video game art street art, merovingian aestheticism nouveau realisme academic, cubo-futurism jugendstil neo-classicism fluxus. Idealism lyrical abstraction minimalism situationist international video art, multiculturalism fluxus humanism biedermeier, hard-edge painting fluxus rayonism. Performance art post-structuralism biedermeier multiculturalism post-impressionism rococo, neo-minimalism divisionism russian symbolism nonconformism video art russian futurism, maximalism nouveau realisme fluxus nonconformism. Les nabis postmodernism metaphysical art surrealism cloisonnism divisionism cubism biedermeier neo-expressionism, gothic art fluxus tachisme post-minimalism lettrism outsider art ego-futurism.

--- a/_content/blog/test copy.md
+++ b/_content/blog/test copy.md
@@ -1,8 +1,0 @@
----
-title: Blog post
-date: 17.9.2023
-author: Oskari.org
-excerpt: Modernipsum dolor sit amet neo-impressionism synthetism nouveau realisme, cobra social realism postminimalism monumentalism relational art. Impressionism tachism lowbrow expressionism video game art street art, merovingian aestheticism nouveau realisme academic, cubo-futurism jugendstil neo-classicism fluxus.
----
-
-Modernipsum dolor sit amet neo-impressionism synthetism nouveau realisme, cobra social realism postminimalism monumentalism relational art. Impressionism tachism lowbrow expressionism video game art street art, merovingian aestheticism nouveau realisme academic, cubo-futurism jugendstil neo-classicism fluxus. Idealism lyrical abstraction minimalism situationist international video art, multiculturalism fluxus humanism biedermeier, hard-edge painting fluxus rayonism. Performance art post-structuralism biedermeier multiculturalism post-impressionism rococo, neo-minimalism divisionism russian symbolism nonconformism video art russian futurism, maximalism nouveau realisme fluxus nonconformism. Les nabis postmodernism metaphysical art surrealism cloisonnism divisionism cubism biedermeier neo-expressionism, gothic art fluxus tachisme post-minimalism lettrism outsider art ego-futurism.

--- a/_content/blog/test.md
+++ b/_content/blog/test.md
@@ -1,8 +1,0 @@
----
-title: Blog post
-date: 11.9.2023
-author: Oskari.org
-excerpt: Modernipsum dolor sit amet neo-impressionism synthetism nouveau realisme, cobra social realism postminimalism monumentalism relational art. Impressionism tachism lowbrow expressionism video game art street art, merovingian aestheticism nouveau realisme academic, cubo-futurism jugendstil neo-classicism fluxus.
----
-
-Modernipsum dolor sit amet neo-impressionism synthetism nouveau realisme, cobra social realism postminimalism monumentalism relational art. Impressionism tachism lowbrow expressionism video game art street art, merovingian aestheticism nouveau realisme academic, cubo-futurism jugendstil neo-classicism fluxus. Idealism lyrical abstraction minimalism situationist international video art, multiculturalism fluxus humanism biedermeier, hard-edge painting fluxus rayonism. Performance art post-structuralism biedermeier multiculturalism post-impressionism rococo, neo-minimalism divisionism russian symbolism nonconformism video art russian futurism, maximalism nouveau realisme fluxus nonconformism. Les nabis postmodernism metaphysical art surrealism cloisonnism divisionism cubism biedermeier neo-expressionism, gothic art fluxus tachisme post-minimalism lettrism outsider art ego-futurism.


### PR DESCRIPTION
Current: https://github.com/oskariorg/oskariorg.github.io/tree/master/_posts

Added `tags: blog`.
Issues:
- images don't work (probably need to be transfered from current impl still, but even the img-tags are removed
- no way to return to blog listing