### PR TITLE
Initial support for mermaid.js in markdown

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -157,6 +157,7 @@ export default makeSource({
   documentTypes: [Docs, Posts, Coordinators, FaqDevelopers, FaqUsers],
   markdown: {
     remarkPlugins: [remarkGfm],
-    rehypePlugins: [rehypeHighlight],
+    // ignore mermaid for highlighting (```mermaid ... ```)
+    rehypePlugins: [[rehypeHighlight, { plainText: ['mermaid'] }]],
   },
 })

--- a/lib/customMarked.ts
+++ b/lib/customMarked.ts
@@ -1,0 +1,18 @@
+import { marked } from 'marked'
+
+marked.use({
+    gfm: true,
+  })
+
+export const MERMAID_SNIPPET = '<pre class="mermaid">'
+
+
+const renderer = new marked.Renderer();
+renderer.code = function (code, language) {
+  if (language === 'mermaid') {
+    return MERMAID_SNIPPET + code + '</pre>';
+  } else {
+    return '<pre><code>' + code + '</code></pre>';
+  }
+};
+export const mdToHtml = (src: string) => marked(src, { renderer: renderer })

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,13 +1,9 @@
 import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
-import { marked } from 'marked'
+import { mdToHtml, MERMAID_SNIPPET } from './customMarked'
 import { insertIdsToHeaders } from './markdownToHtml'
 import { DocAnchorLinksType, VersionDocType } from '@/types/types'
-
-marked.use({
-  gfm: true,
-})
 
 export function slugify(input: string): string {
   return input
@@ -24,7 +20,7 @@ function compileMarkdownToHTML(markdown: string): {
   anchorLinks: VersionDocType['anchorLinks']
 } {
   const { content } = matter(markdown)
-  const markedHtml = marked(content)
+  const markedHtml = mdToHtml(content)
   const { html, anchorLinks } = insertIdsToHeaders(markedHtml)
   return {
     html,
@@ -102,6 +98,18 @@ export function generateVersionDocs(
         anchorLinks.push(...compiledAnchorLinks)
         html += compiledHTML
       }
+    }
+    // inject script to make mermaid js work its magic
+    if (html.includes(MERMAID_SNIPPET)) {
+      html += `<script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js"></script>
+      <script>
+      mermaid.initialize({
+        startOnLoad:true,
+        htmlLabels:true,
+        theme: 'base'
+      });
+      </script>
+      `
     }
 
     topics.push({

--- a/styles/_md-styles.scss
+++ b/styles/_md-styles.scss
@@ -155,7 +155,7 @@
     content: '';
   }
 
-  & pre {
+  & pre:not(.mermaid) {
     color: var(--color-light);
     background-color: rgba(0, 0, 0, 0.75);
     overflow-x: auto;


### PR DESCRIPTION

Enables rendering diagrams like this:
![image](https://github.com/testomuli/Oskari-web-nextjs/assets/2210335/191c320a-6337-47f7-a378-c5f61210e66f)

Using snippets like this on the md-files under documentation:
```
 ```mermaid
sequenceDiagram
    Alice->John: Hello John, how are you?
    loop Every minute
        John-->Alice: Great!
    end
 ```
```

It's a bit slow to render on the client. We should try to make mermaid pre-render the SVG on build instead.